### PR TITLE
Fix the ContentDB half of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,26 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Makes a re-run after a later step failed a no-op instead of an error.
+          skip-existing: true
 
       - name: Publish to ContentDB
         env:
           CONTENTDB_API_TOKEN: ${{ secrets.CONTENTDB_API_TOKEN }}
           RELEASE_NOTES: ${{ github.event.release.body }}
         run: |
-          python -c 'import json, os; tag = os.environ["GITHUB_REF_NAME"]; print(json.dumps({"method": "git", "title": tag, "ref": tag, "release_notes": os.environ["RELEASE_NOTES"]}))' \
-          | curl --fail-with-body -sS \
+          # ContentDB's "git" method clones the repository and expects to find a mod
+          # at its root. Ours lives in mod_data/, and the API has no field to point
+          # at a subdirectory, so upload the mod folder as a zip instead.
+          (cd mod_data && zip -q -r ../miney-mod.zip miney)
+          # Write the notes to a file: curl -F reads a leading "@" or "<" in an
+          # inline value as a filename, and release notes may start with anything.
+          printf '%s' "$RELEASE_NOTES" > release-notes.md
+          curl --fail-with-body -sS \
               -X POST "https://content.luanti.org/api/packages/Miney/miney/releases/new/" \
               -H "Authorization: Bearer $CONTENTDB_API_TOKEN" \
-              -H "Content-Type: application/json" \
-              --data-binary @-
+              -F "title=$GITHUB_REF_NAME" \
+              -F "commit=$GITHUB_SHA" \
+              -F "release_notes=<release-notes.md" \
+              -F "file=@miney-mod.zip"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,14 @@ the same tag. The GitHub release body becomes the ContentDB release notes verbat
 
 Tags are `v0.6.0`. PyPI gets `0.6.0` — the workflow strips the `v`.
 
+The ContentDB half uploads `mod_data/miney/` as a zip and does **not** use ContentDB's
+`method: git`. That method clones the repository and expects a mod at its root; our mod
+sits in `mod_data/`, and neither the API nor `.cdb.json` has a field to point at a
+subdirectory. A git release therefore fails asynchronously with *"Expected a mod or
+modpack, found unknown"* — the API call itself returns `success: true`, so nothing goes
+red. If a release ever looks fine but no new version shows up on ContentDB, open the
+task URL from the API response; that is where the real error is.
+
 A release is a pull request plus one command:
 
 1. On `dev`: bump `__version__` in `miney/__init__.py`, give `docs/changelog.rst` its
@@ -172,8 +180,11 @@ There is no way to rehearse a release. The workflow only ever runs on a real
 not a dry run.
 
 If a run fails: the version guard runs before every publish and PyPI before ContentDB, so
-a failure leaves the later registries untouched. Delete the GitHub release and its tag,
-fix, tag again.
+a failure leaves the later registries untouched. Fix the cause, then delete the GitHub
+release and create it again on the same tag — that fires a fresh `release: published`
+event, and GitHub reads the workflow from `master`, so the re-run picks up the fix. PyPI
+is set to `skip-existing`, so an already-published version is skipped rather than failing
+the run. Only delete the tag as well if the code itself has to change.
 
 ## Tests
 


### PR DESCRIPTION
The v0.6.0 run went green and published to PyPI, but ContentDB never got the release.

ContentDB's `method: git` clones the repository and expects a mod at its root. The miney mod lives in `mod_data/`, and neither the release API nor `.cdb.json` has a field to point at a subdirectory, so the import failed asynchronously with *"Expected a mod or modpack, found unknown"*.

It failed quietly — the API call returns `success: true` and queues a background task, so nothing turned red.

**Now:** the step zips `mod_data/miney` and uploads it, which is how every earlier release of this package was made. PyPI gains `skip-existing`, so re-running a release after fixing a later step is a no-op instead of an error.

After merging, deleting and recreating the v0.6.0 GitHub release on the same tag re-fires the workflow with this fix in place.
