### PR TITLE
v0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ uv.lock
 # miney
 tmp
 Minetest
+# upstream C++ sources, reference only for the native client protocol
+luanti-src
 docs/superpowers
 .miney/
 

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ docs/superpowers
 coverage.xml
 htmlcov/
 .superpowers
+
+# local demo playground, not part of the library
+/demo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,12 @@ modpack, found unknown"* — the API call itself returns `success: true`, so not
 red. If a release ever looks fine but no new version shows up on ContentDB, open the
 task URL from the API response; that is where the real error is.
 
+Release titles are unique per package on ContentDB, and a failed import keeps its name.
+Retrying after a failure gives `{"error":"A release with this name already exists"}` until
+the broken release is deleted by hand at
+`https://content.luanti.org/packages/Miney/miney/releases/`. A release with `size: 0` and
+`url: null` in the API listing is one of those corpses.
+
 A release is a pull request plus one command:
 
 1. On `dev`: bump `__version__` in `miney/__init__.py`, give `docs/changelog.rst` its
@@ -165,11 +171,17 @@ A release is a pull request plus one command:
 
 Nothing else triggers a publish. Pushing a tag does not, merging to `master` does not.
 
-The workflow file has to live on `master` for the release event to see it at all — that
-is a GitHub rule for repository-level events, so a release workflow edit only takes
-effect after it has been merged. That is also why the pull request comes first and the
-`gh release create` second: by the time the release event fires, `master` already carries
-the workflow. No separate push is needed for it.
+The workflow file has to live on `master` for the release event to fire at all — that is a
+GitHub rule for repository-level events. But the version that actually *runs* is the one
+in **the commit the tag points at**, not the current `master`. Both together give one
+rule: tag a commit of `master` that already contains the workflow you want to run.
+
+That is why the pull request comes first and `gh release create` second. It also means a
+workflow fix does not reach an existing tag: merging the fix to `master` changes nothing
+for `v0.6.0`, because that tag still points at the commit before it. Re-tagging is the
+only way, and it is only acceptable while nothing but the workflow has changed — check
+with `git diff --stat <tag>..master -- miney/ mod_data/ pyproject.toml` and expect it to
+be empty.
 
 Editing `release.yml` has one trap worth remembering: naming **any** entry under
 `permissions:` sets every unnamed scope to `none`. Adding `id-token: write` for PyPI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,14 @@ is — write for them, and the experienced reader is fine too.
 - Work happens on `dev`. `master` gets changes via PR. Don't commit to `master` directly.
 - Public API is re-exported in `miney/__init__.py` and listed in `__all__` — new public names belong in both.
 - Version is `__version__` in `miney/__init__.py`; `pyproject.toml` reads it statically via `[tool.setuptools.dynamic]`. There is no second place to bump.
+- The two halves have their own contract number, and it is **not** the release version:
+  `MOD_API` in `mod_data/miney/init.lua` and `REQUIRED_MOD_API` in `miney/lua.py`. The
+  mod sends its number with every answer and `Lua.run` refuses anything older, so a
+  server still carrying last year's mod gets a sentence telling it to update instead of
+  a nil index deep inside somebody's script. Raise both together when a command, a
+  field or a name in the sandbox changes so that an older Python would not survive it —
+  and leave them alone at release time. `mod.conf` is not an option for this: Luanti's
+  spec has no `version` field, and its `release` belongs to ContentDB.
 - Every user-visible change gets a `docs/changelog.rst` entry under the *unreleased* version heading — added, changed, fixed. Write it in the same commit as the change, not at release time. Internal refactoring, tests and tooling stay out; the changelog is read by users, not by us.
 
 ## Releases

--- a/docs/api/Luanti.rst
+++ b/docs/api/Luanti.rst
@@ -46,4 +46,5 @@ All interaction with the game world starts with the ``Luanti`` object. The follo
    nodes
    players
    point
+   storage
    tool

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -2,7 +2,179 @@
 Events
 ======
 
-This module contains data structures for events received from the server.
+An event is something that happened in the world. You say which one you care about, and
+Miney runs your function when it happens - see :meth:`lt.callbacks.on()
+<miney.callback.Callback.on>` for how to register one, and
+:meth:`~miney.callback.Callback.register` for the same thing without a decorator.
+
+Your function is handed one argument: an event object. Which one depends on the event
+you subscribed to, and every field it carries is listed below.
+
+.. code-block:: python
+
+    import miney
+
+    with miney.Luanti() as lt:
+
+        @lt.callbacks.on("node_dug")
+        def someone_dug(event):
+            print(f"{event.player_name} dug {event.node_name} at {event.pos}")
+
+        input("Dig a block in the game. Press Enter to stop.\n")
+
+The events
+==========
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 30 48
+
+   * - Name
+     - Event object
+     - When it happens
+   * - ``chat_message``
+     - :class:`~miney.events.ChatMessageEvent`
+     - A player sends a line of chat. Not for ``/commands`` - see below.
+   * - ``player_joins``
+     - :class:`~miney.events.PlayerJoinsEvent`
+     - A player finished logging in and is in the world.
+   * - ``player_leaves``
+     - :class:`~miney.events.PlayerLeavesEvent`
+     - A player leaves, is kicked, or times out.
+   * - ``node_dug``
+     - :class:`~miney.events.NodeDugEvent`
+     - A block was dug away.
+   * - ``node_placed``
+     - :class:`~miney.events.NodePlacedEvent`
+     - A block was placed.
+   * - ``node_punched``
+     - :class:`~miney.events.NodePunchedEvent`
+     - A block was hit, without necessarily being dug.
+   * - ``player_dies``
+     - :class:`~miney.events.PlayerDiesEvent`
+     - A player died.
+   * - ``player_respawns``
+     - :class:`~miney.events.PlayerRespawnsEvent`
+     - A player comes back, before the game moves them.
+   * - ``player_punched``
+     - :class:`~miney.events.PlayerPunchedEvent`
+     - A player was hit by someone or something.
+   * - ``player_hp_changed``
+     - :class:`~miney.events.PlayerHpChangedEvent`
+     - A player lost or gained health.
+
+A chat command you registered yourself with :meth:`lt.chat.command()
+<miney.Chat.command>` arrives as a :class:`~miney.events.ChatCommandEvent`. It is
+not in the table because you do not subscribe to it - registering the command is the
+subscription.
+
+Three worked examples
+=====================
+
+**A trap door.** Dig one particular block, fall into the dark:
+
+.. code-block:: python
+
+    import miney
+    from miney import Point
+
+    with miney.Luanti() as lt:
+
+        @lt.callbacks.on("node_dug", {"node_name": "mcl_core:goldblock"})
+        def trapdoor(event):
+            lt.nodes.fill(event.pos + Point(0, -1, 0), event.pos + Point(0, -8, 0), "air")
+            lt.chat.send_to_player(event.player_name, "Should have left that alone.")
+
+        input("Dig a gold block. Press Enter to stop.\n")
+
+The filter is the interesting part: the comparison happens on the server, so every other
+block anybody digs never even reaches your script.
+
+**A safety net.** Send a player home instead of letting them respawn wherever the game
+would put them:
+
+.. code-block:: python
+
+    HOME = Point(0, 20, 0)
+
+    @lt.callbacks.on("player_dies")
+    def condolences(event):
+        lt.chat.send_to_all(f"{event.player_name} died of {event.reason}.")
+
+    @lt.callbacks.on("player_respawns")
+    def straight_home(event):
+        lt.players[event.player_name].move(destination=HOME)
+
+Two events, because they are two moments: the player is dead at the first one and still
+lying where they fell. The game repositions them *after* ``player_respawns``, which is
+why the move belongs there and not at death.
+
+**A health bar in the chat**, in three lines:
+
+.. code-block:: python
+
+    @lt.callbacks.on("player_hp_changed")
+    def hearts(event):
+        full = int(event.hp) // 2
+        lt.chat.send_to_player(event.player_name, "♥" * full + "·" * (10 - full))
+
+Filters
+=======
+
+A filter is a dictionary of event fields and the values worth waking up for. Every named
+field has to match; a list accepts any one of its values:
+
+.. code-block:: python
+
+    @lt.callbacks.on("node_placed", {"node_name": ["mcl_core:lava_source", "mcl_core:tnt"]})
+    def no_griefing(event):
+        lt.nodes.set(miney.Node(event.pos.x, event.pos.y, event.pos.z, "air"))
+        lt.chat.send_to_all(f"Not on my server, {event.player_name}.")
+
+The comparison happens in the mod, before anything is sent, so what a filter rejects
+costs no network at all. That is what makes a filter worth setting on the busy events:
+``node_dug`` and ``node_placed`` fire for every block every player touches, and an
+unfiltered handler on a populated server is a lot of Python for very little.
+
+.. important::
+
+   A filter value is compared with ``==``. It has to be a string, a number, a boolean,
+   or a list of those - **a position cannot be filtered on**. ``{"pos": Point(1, 2, 3)}``
+   raises a :class:`ValueError` where you typed it, rather than quietly matching nothing.
+   Ask for the whole event and decide in your own code:
+
+   .. code-block:: python
+
+       @lt.callbacks.on("node_dug")
+       def bedrock_watch(event):
+           if event.pos.y < 5:
+               lt.chat.send_to_all("Somebody is digging near the bottom of the world.")
+
+Things that will surprise you
+=============================
+
+- **A chat command is not a chat message.** Luanti's own handler takes every line
+  starting with ``/`` and stops the chain, so ``chat_message`` never sees it. Register
+  the command with :meth:`lt.chat.command() <miney.Chat.command>` instead.
+- **Blocks a script writes send no block events at all.** Neither
+  :meth:`lt.nodes.fill() <miney.Nodes.fill>` nor :meth:`lt.nodes.set()
+  <miney.Nodes.set>` sends ``node_placed`` or ``node_dug`` - the first writes through
+  the bulk map interface, and the second sets the block directly rather than *placing*
+  it the way a player does. These events are about what the people in the world do, and
+  a handler that builds cannot set itself off by accident.
+- **Not everybody has a name.** A block dug by falling gravel, a player hit by a mob:
+  ``player_name`` and ``hitter_name`` are then an empty string, not ``None``.
+- **Miney's own player picks itself up.** When the player Miney logged in as dies, Miney
+  respawns it - so a ``player_dies`` for that name is followed by a ``player_respawns``
+  a moment later without anybody asking for it. Everybody else keeps the death screen
+  they are supposed to get.
+- **Your handler runs on Miney's callback thread.** A handler that sleeps for ten seconds
+  delays every other event by ten seconds. Keep it short.
+- **An exception in your handler is logged, not raised.** It cannot take the session down
+  with it, so watch your terminal when a handler seems to do nothing.
+
+Reference
+=========
 
 .. automodule:: miney.events
    :members:

--- a/docs/api/nodes.rst
+++ b/docs/api/nodes.rst
@@ -4,6 +4,32 @@ Nodes
 The ``Nodes`` object provides methods to get and manipulate nodes in the game world.
 When you retrieve a node, it is returned as a :class:`~miney.node.Node` object, which contains its position, name, and other properties.
 
+.. rubric:: Two ways to build
+
+There are two, and picking the right one is the difference between a wall appearing and
+a wall taking three minutes to appear.
+
+:meth:`~miney.Nodes.set` places blocks the way the game does. Every block is placed
+properly: a chest gets its inventory, sand falls, water flows, a door works. It sends one
+instruction per block, so its cost grows with the number of blocks — about 700 a second.
+Use it for one block, or for a few hundred, or whenever the blocks have to *behave*.
+
+:meth:`~miney.Nodes.fill` fills a box with one kind of block. It sends the two corners
+and a name, and the server does the rest, so **the size of the box does not reach the
+network at all**: a floor of four thousand blocks and a hillside of three million cost
+the same to ask for. Roughly 4,700,000 blocks a second. In exchange it writes blocks and
+nothing else — no chest inventories, no falling sand, no flowing water. For floors,
+walls, towers and clearing ground, which is most of building, that is exactly what you
+want.
+
+.. code-block:: python
+
+   from miney import Point, Node
+
+   lt.nodes.fill(Point(0, 10, 0), Point(63, 10, 63), "mcl_core:obsidian")  # a floor
+   lt.nodes.fill(Point(0, 11, 0), Point(63, 74, 63), "air")                # clear above it
+   lt.nodes.set(Node(32, 11, 32, name="mcl_chests:chest"))                 # a working chest
+
 .. autoclass:: miney.Nodes
    :members:
 

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -1,0 +1,37 @@
+Storage
+=======
+
+A script forgets everything when it ends. Python variables are gone with the process,
+and the Lua names from :meth:`~miney.Lua.run` are gone with the connection. ``lt.storage``
+is the exception: what you write here is stored in the world and is still there the next
+time you run your script, and after the server was restarted.
+
+It is a dictionary, so there is nothing new to learn - ``in``, ``len()``, ``for``,
+``.get()``, ``.pop()``, ``.update()`` and ``del`` behave the way you expect.
+
+:Example:
+
+    >>> lt.storage["home"] = "10,20,30"
+    >>> lt.storage["home"]
+    '10,20,30'
+    >>> "home" in lt.storage
+    True
+    >>> del lt.storage["home"]
+
+Keys and values are always strings, because that is all Luanti stores. Miney does not
+hide that: a number raises a :class:`TypeError` rather than coming back as text you did
+not write. Use :class:`str` for single values and :mod:`json` for lists and dictionaries.
+
+.. important::
+
+   There is one store per world, shared by every Miney script connected to it - it is a
+   noticeboard, not a private drawer. Give your keys a prefix if more than one project
+   uses the same world.
+
+   The keys belong to Miney alone: Luanti files them under the mod that wrote them, so
+   no other mod on the server sees them, and you never collide with one. That is a
+   namespace and not a secret - the store is a plain file in the world directory.
+
+.. autoclass:: miney.Storage
+   :members:
+   :special-members: __getitem__, __setitem__, __delitem__, __iter__, __len__

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,65 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 removed and security sections),
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
-----------
+v0.7.0
+------
+
+A big release of small repairs. Blocks placed away from a player arrived nowhere, event
+filters were accepted and ignored, a smooth move looked the wrong way when it landed, and
+a script could not be run twice in a row - all of that works now. Uploading and reading
+the world got faster, seven new events let a script react to what people do, and the Lua
+sandbox no longer hands out the server's file system.
+
+Nothing was removed or renamed, so every call a v0.6.0 script makes still exists. A few
+things behave differently, and one of them - the Lua mod on the server has to be the one
+that ships with this release - stops a script before it starts. They are listed below.
+
+**Breaking**
+
+Version 0.6.0 is a day old, so the release most people are coming from is 0.5.8. This
+section covers everything since then, 0.6.0 included.
+
+- **The Lua mod on the server has to be updated.** The two halves ship together and
+  have their own version number, which this release raises. Miney checks it on the first
+  call and refuses with a sentence naming the fix, rather than failing somewhere inside
+  your own Lua. For a world started with the ``miney`` command that is
+  ``uv run miney upgrade``; on somebody else's server the admin updates the mod from
+  `ContentDB <https://content.luanti.org/packages/Miney/miney/>`_.
+- **Python 3.10 is the minimum version** (since v0.6.0, was 3.6).
+- **Event filters are applied now**, and a script written against a version that ignored
+  them sees fewer events. ``lt.callbacks.on("chat_message", {"sender_name": "Steve"})``
+  used to call the handler for every message from everyone; it now calls it for Steve.
+  Registrations that relied on that - a filter written and then worked around in the
+  handler - keep working, but a handler that was never told about the filter now runs
+  less often. A filter naming a field the event does not carry raises instead of matching
+  nothing, and so does a filter value the server cannot compare with ``==``, such as a
+  :class:`~miney.Point`.
+- **Lua names belong to one connection.** A global assigned in :meth:`~miney.Lua.run` used
+  to stay visible to every other script on the server until it restarted; now each
+  connection has its own set and it is cleared when the connection ends. A script that
+  picked up a value another script had left behind has to pass it on itself -
+  :attr:`lt.storage <miney.Luanti.storage>` is the place for that.
+- **``getfenv`` is gone from the Lua sandbox**, along with the way it gave to the
+  server's real globals and its file system.
+- **Lua sent to :meth:`~miney.Lua.run` has an instruction budget.** Code that does not
+  return after about a tenth of a second of Lua steps is stopped and comes back as an
+  error. It exists because such code used to freeze the whole server. Waiting for the
+  engine does not count, so ordinary work is unaffected - a deliberately long computation
+  in one call is not, and has to be split.
+- **A timer outlives its script no longer.** Anything scheduled with ``minetest.after``
+  is cancelled when the connection that asked for it goes. That is what stops a runaway
+  animation, and it also means a script cannot arm something and exit expecting it to
+  fire.
+- **:meth:`lt.nodes.set() <miney.Nodes.set>` raises instead of doing nothing.** A node
+  name on its own, or a list with a :class:`~miney.Point` in it, used to be accepted
+  silently and place no blocks; it now raises :class:`TypeError`. Code that appeared to
+  work and did not will start reporting itself.
+- **A second smooth :meth:`~miney.Player.move` replaces the first** instead of running
+  alongside it.
+- **:meth:`player.move(look_at=...) <miney.Player.move>` tilts the right way.** The
+  smooth path measured pitch upwards where Luanti measures it downwards, so a script that
+  compensated by negating its own angle has to stop doing that. Without ``smooth`` the
+  call raised for every target, so there is nothing to undo there.
 
 **Added**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,20 @@ Unreleased
 
 **Added**
 
+- Seven more events to subscribe to with :meth:`lt.callbacks.on()
+  <miney.callback.Callback.on>`, so a script can react to the world and not only to the
+  chat: ``node_dug``, ``node_placed`` and ``node_punched`` for blocks, ``player_dies``,
+  ``player_respawns``, ``player_punched`` and ``player_hp_changed`` for the people in it.
+  Nothing about the API changes - the event name is a string, filters and handlers work
+  as before - and every one of them, with what it carries and when it happens, is
+  documented in :mod:`miney.events`.
+
+  The block events carry the position as a :class:`~miney.Point`, so it can be handed
+  straight to :meth:`~miney.Nodes.set` or :meth:`~miney.Player.move`. They report what
+  the people in the world do: blocks a script writes with :meth:`~miney.Nodes.set` or
+  :meth:`~miney.Nodes.fill` send nothing, so a handler that builds cannot set itself
+  off.
+
 - :attr:`lt.storage <miney.Luanti.storage>`, the world's key-value store, used like a
   dictionary: ``lt.storage["home"] = "10,20,30"`` is still there the next time the script
   runs, and after a server restart. Keys and values are strings, because that is what
@@ -22,6 +36,21 @@ Unreleased
   server where the mod was installed by hand or from ContentDB and only the Python side
   was updated - and the symptom used to be an error inside your own Lua, naming
   something the old mod had never heard of.
+
+- :meth:`lt.nodes.fill() <miney.Nodes.fill>`, which fills a box with one kind of block
+  and does not care how big the box is. Only the two corners and a name go over the
+  network, so a floor of four thousand blocks and a hillside of three million cost the
+  same to ask for - measured at 4,700,000 blocks a second against
+  :meth:`~miney.Nodes.set`'s 700, and a 193x76x193 site levelled in 0.27 seconds. It
+  writes blocks and nothing else: no chest inventories, no falling sand, no flowing
+  water. :meth:`~miney.Nodes.set` remains the way to place a block that has to work.
+
+- ``wait=True`` on :meth:`~miney.Player.move`, for when the next line needs the player
+  to have arrived. A smooth move still returns straight away by default - that is how a
+  camera flies over a building site while the building goes on - but the alternative
+  used to be ``time.sleep(duration)``, which repeats a number that is already an
+  argument and is always slightly too short, because a frame is scheduled for the next
+  server step and never sooner.
 
 **Security**
 
@@ -35,6 +64,17 @@ Unreleased
 
 **Changed**
 
+- A filter value has to be something the server can compare with ``==`` - a string, a
+  number, a boolean, or a list of those - and anything else raises where it was written.
+  The value that made this necessary is a position: ``{"pos": Point(1, 2, 3)}`` reads
+  like the most obvious filter there is, and the comparison would have rejected every
+  event for the rest of the session without a word about why. Ask for the event and
+  decide in your own code instead: ``if event.pos.y < 10:``.
+
+- A second :meth:`~miney.Player.move` with ``smooth=True`` on the same player replaces
+  the first instead of running alongside it. Two animations both set the position every
+  frame, each from the start it remembered, so the player drifted between the two paths
+  and reached neither.
 - Miney no longer announces itself in the chat. A script connecting and disconnecting
   used to print ``*** Miney joined the game.`` and ``*** Miney left the game.`` to
   everyone on the server, once per run. Messages from real players are untouched.
@@ -42,6 +82,131 @@ Unreleased
   your connection alone, and that the sandbox has no ``_G``.
 
 **Fixed**
+
+- Miney's own player gets up again after it dies. It used to stay dead for the rest of
+  the session - a corpse standing where it fell, reporting that position for every
+  :attr:`~miney.Player.position` read and refusing to be moved anywhere useful. The
+  client does answer the death screen, but the server only accepts an answer to the form
+  it is still expecting, and the mod shows its own form for every result and every event,
+  including the one announcing the death. Miney now asks the server for the respawn
+  through the Lua channel that is open anyway, and hides the player again afterwards if
+  the session asked for an invisible one.
+
+- A second world no longer takes the answer away from everything else in the project.
+  ``miney.Luanti()``, ``miney start`` and ``miney stop`` used to look only at what was on
+  disk, so the moment a second world existed - a test world, a tutorial world, one left
+  over from an experiment - every command that had not been told a name gave up with
+  *"Several worlds exist"*, and kept giving up after everything was shut down again. They
+  now share one rule: the world on the port that was asked for, the only world there is,
+  or **the only one that is running**. Starting a world therefore answers the question for
+  every command that follows it. When it really cannot be told, the message lists the
+  worlds with their status and suggests the one worked in last, rather than the first one
+  alphabetically, and ``miney stop`` says which worlds are up instead of quietly stopping
+  nothing.
+
+  A bare ``miney start`` in a project with several worlds now opens the one worked in
+  last as well. It used to reach for the world named after the default game, which -
+  with two worlds already there and neither of them that one - meant **creating a third**:
+  a first start, a full map generation and minutes of waiting for a world nobody asked
+  for. Creating a world now says so before it happens, and the wait afterwards says
+  whether it is generating a map or loading the game's mods, so a normal twenty-second
+  VoxeLibre start stops reading like a hang.
+
+- :attr:`player.invisible <miney.Player.invisible>` ``= False`` gives the player back
+  what they looked like. It used to put back a guess: a hitbox 2 nodes tall whatever the
+  game says - VoxeLibre's is 1.7 - and a model still wearing the transparent texture that
+  hid it, so the player stayed invisible while claiming to be visible again. What they
+  looked like is now written into their metadata before they are hidden and set back from
+  there, so the skin, the model and the real hitbox return. It survives a script that ends
+  while its player is hidden, because the note is stored with the player and not in the
+  script.
+
+- A chat command whose handler is a callable object works. The dispatcher asked whether
+  the handler it had found was *true* rather than whether it was *there*, and an object
+  that reports itself empty - a collector, a queue, a counter at zero - answers no. Its
+  events were dropped without a word, and because such a handler only stops being empty
+  by being called, it stayed silent for the whole run. Plain functions were never
+  affected, and neither was the event side of :class:`~miney.callback.Callback`.
+
+- Event filters do something now. ``lt.callbacks.on("chat_message", {"sender_name":
+  "Steve"})`` accepted the filter, sent it to the server and the mod dropped it on the
+  floor, so the handler ran for every message from everyone and nothing anywhere said
+  otherwise. The comparison now happens on the server, before the event is sent, so what
+  a filter rejects never travels. A list accepts any one of its values, every named field
+  has to match, and a field the event does not carry - ``{"sender": ...}`` for a message
+  that has ``sender_name`` - raises and names the fields that exist, instead of silently
+  matching nothing. The filter belongs to the handler you registered it with, so you can
+  watch the same event twice for two different things and each function only sees what it
+  asked for.
+
+- A timer started by your script now ends with your script. Anything scheduled with
+  ``minetest.after``, including the animation behind
+  :meth:`player.move(smooth=True) <miney.Player.move>`, was handed to the engine and
+  then forgotten: it kept running after the script ended, after ``lt.disconnect()`` and
+  after the Python process was gone, and since each connection has its own set of Lua
+  names, a later script could not even see the variables the loop was built from. Only
+  restarting the server stopped it. So ``player.move(..., smooth=True, duration=600)``
+  - one typo away from ``60`` - dragged the player for ten minutes, and moving them
+  somewhere else did not help: the next frame recomputed the position from the start
+  the animation remembered and pulled them back. Every timer now belongs to the
+  connection that asked for it, and the server cancels what is left when that
+  connection goes, however it goes.
+
+- Uploading is no longer paced by a fixed pause, and a lost packet is no longer lost for
+  good. Miney sent reliable packets and never retransmitted them, so it had to send
+  slowly enough that nothing was dropped - 495 bytes every 10 milliseconds, about
+  45 KB/s, which meant half a minute for a large piece of Lua. Luanti acknowledges every
+  reliable packet it accepts and deliberately stays silent about one that arrives too
+  early, expecting the sender to try again; Miney now keeps each packet until that
+  acknowledgement arrives and resends it if it does not. What limits the rate instead is
+  64 packets in flight, so a fast link runs at its own speed and a slow one is throttled
+  to a window per round trip. Measured on a local server, with the payload checksummed
+  on arrival: 600 KB went from 12.7 seconds to 0.04.
+
+- :meth:`lt.nodes.get() <miney.Nodes.get>` reads a region about thirty times faster,
+  and returns exactly what it did before. The time was never in reading the world - it
+  was in describing it, one table of five values per node on its way back. A region now
+  sends each node name once and collapses runs of identical neighbours, which is what
+  terrain mostly is. Reading a 32x32x32 region went from 0.93 seconds to 0.03; a
+  24x24x24 one from 0.53 to 0.01. Order, contents and types of the returned list are
+  unchanged, checked node by node against the old implementation.
+
+- :meth:`lt.nodes.set() <miney.Nodes.set>` no longer loses blocks that are placed away
+  from a player. ``minetest.set_node`` does nothing in a part of the world the server
+  does not currently hold in memory - it does not load it and it does not complain - so
+  building anywhere nobody was standing produced no blocks, no error and a script that
+  reported success. Measured on an unloaded area, none of fifty blocks arrived; all
+  fifty do now. The area is loaded first, once per 16x16x16 mapblock rather than once
+  per block, so scattered positions cannot ask the server to load everything in between
+  them.
+
+- Running a script twice in a row works again. A script that ends without ``with`` never
+  disconnected: every namespace on :class:`~miney.Luanti` refers back to it, so it is
+  only reachable in a reference cycle, and the collector that could free it is not
+  guaranteed to run when the interpreter shuts down. The server therefore kept the
+  session open, and the next run was refused with *"Another client is already connected
+  with this name."* The disconnect is now registered with :mod:`atexit`, which runs while
+  the interpreter is still whole.
+
+- :meth:`player.move(destination=..., look_at=..., smooth=True) <miney.Player.move>`
+  arrives looking at the target. The angles were worked out from where the player set
+  off instead of where they were going, so the camera finished pointing along the old
+  sight line - and the further it flew, the wider it missed. Measured on the demo's
+  camera, which flies about a hundred nodes between two acts: 127 degrees off, meaning
+  the thing it had flown to see was behind it. It now lands within a hundredth of a
+  degree, which is what the instant version already did.
+
+- :meth:`player.move(look_at=...) <miney.Player.move>` aims at the target. Without
+  ``smooth`` it called ``set_look_dir``, which Luanti does not have, and raised
+  *attempt to call method 'set_look_dir' (a nil value)* for every target; the same call
+  made :attr:`~miney.Player.look_dir` impossible to assign. With ``smooth`` it did work,
+  but tilted the wrong way: Luanti measures this pitch as positive downwards and the
+  angle it was given was positive upwards, so looking 45 degrees up aimed 45 degrees
+  down. Both paths now agree and land within a hundredth of a degree.
+
+- :meth:`~miney.Chat.format_message` returns a formatted message instead of raising.
+  Both arguments went into the Lua source unquoted, so any message containing a space
+  was a syntax error and one without a space silently read two undefined globals.
 
 - A variable assigned in :meth:`~miney.Lua.run` no longer leaks into everybody else's
   scripts. All connections shared one sandbox, so a name assigned by one script stayed
@@ -65,6 +230,41 @@ Unreleased
   who had never written a line of Lua, because the value was escaped the way JSON does
   it and Lua has no ``\u`` escape. Affected every value on its way into Lua, so also
   node names, player names and chat commands.
+
+- :meth:`lt.nodes.set() <miney.Nodes.set>` accepts any collection of nodes - a tuple, a
+  set, a generator - and says so when it is handed something else. It used to check for
+  a :class:`list` exactly, and do nothing at all for anything that was not one: a tuple
+  looks like the documented call, placed no blocks, raised nothing and returned nothing.
+  A subclass of :class:`~miney.node.Node` was refused for the same reason. Passing a
+  node name on its own, or a list with a :class:`~miney.point.Point` in it, now raises a
+  :class:`TypeError` naming what arrived and showing the call that works.
+
+- :meth:`lt.nodes.get() <miney.Nodes.get>` explains itself instead of returning
+  ``None``. Anything that was not a point or a pair of points fell off the end of the
+  function, so asking for three corners of a cuboid - a reasonable thing to try - gave
+  back nothing at all.
+
+- :class:`~miney.inventory.Inventory` raises when it belongs to neither a player nor a
+  node. All four of its methods asked what they were attached to, and returned ``None``
+  or an empty list for anything else, so a wrongly built inventory was indistinguishable
+  from an empty one.
+
+- :class:`~miney.Inventory` quotes what it is given. The item name, the amount, the
+  player name and the inventory list name all went into the Lua source as-is, so an item
+  name containing a quote either failed with a Lua syntax error or ran as Lua - the same
+  hole that :meth:`~miney.Chat.format_message` had. All four now go through
+  :meth:`~miney.Lua.dumps`.
+
+- :meth:`~miney.Inventory.get_list` and :meth:`~miney.Inventory.get_lists` return an
+  empty list for an empty inventory instead of ``None``. An empty Lua table arrives on
+  the Python side as ``None``, so looping over the contents of an empty chest raised
+  *'NoneType' object is not iterable*. ``get_list()`` also documents what it really
+  returns: the occupied slots, not one entry per slot.
+
+- ``lt.players["Nobody"]`` raises :class:`~miney.exceptions.PlayerNotFoundError` and
+  lists who *is* online, which is nearly always the next question. It used to raise
+  ``IndexError("unknown player")``. The new exception is a subclass of ``IndexError``,
+  so scripts catching the old one keep working.
 
 v0.6.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,65 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 removed and security sections),
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+----------
+
+**Added**
+
+- :attr:`lt.storage <miney.Luanti.storage>`, the world's key-value store, used like a
+  dictionary: ``lt.storage["home"] = "10,20,30"`` is still there the next time the script
+  runs, and after a server restart. Keys and values are strings, because that is what
+  Luanti stores - use :class:`str` and :mod:`json` on the way in.
+- ``storage`` in the :meth:`~miney.Lua.run` sandbox, the same store seen from Lua.
+- Miney checks that the Lua mod on the server is new enough to talk to, and says so
+  before running anything. The two halves ship together, so they only come apart on a
+  server where the mod was installed by hand or from ContentDB and only the Python side
+  was updated - and the symptom used to be an error inside your own Lua, naming
+  something the old mod had never heard of.
+
+**Security**
+
+- The Lua sandbox handed out a way back to the server's real globals, and with them the
+  file system. ``getfenv`` was part of the sandbox, and Lua defines ``getfenv(0)`` as
+  *the global environment*, so ``getfenv(0).io.open(...)`` read and wrote files on the
+  machine running the server, ``getfenv(0).x = 1`` was visible to every other script,
+  and the per-connection isolation below was decorative. ``getfenv`` is gone from the
+  sandbox. It remains true that the ``miney`` privilege means running code inside the
+  server - the privilege now says so, and so does the documentation.
+
+**Changed**
+
+- Miney no longer announces itself in the chat. A script connecting and disconnecting
+  used to print ``*** Miney joined the game.`` and ``*** Miney left the game.`` to
+  everyone on the server, once per run. Messages from real players are untouched.
+- :meth:`~miney.Lua.run` documents that Lua globals survive between calls, belong to
+  your connection alone, and that the sandbox has no ``_G``.
+
+**Fixed**
+
+- A variable assigned in :meth:`~miney.Lua.run` no longer leaks into everybody else's
+  scripts. All connections shared one sandbox, so a name assigned by one script stayed
+  visible to every other script on the server until it restarted - and overwriting a
+  name the sandbox provides, ``minetest = nil``, disabled Miney for the whole server.
+  Each connection now has its own set of names, cleared when it ends.
+
+- A Lua loop that never ends no longer freezes the server. Lua sent to
+  :meth:`~miney.Lua.run` runs inside the server's own step, so ``while true do end``
+  stopped the world for everybody until somebody killed the process, losing whatever had
+  not been saved. Such a loop is now stopped after about a tenth of a second and comes
+  back as an error that says what happened. Scripts that do real work are unaffected -
+  the count is of Lua steps, and waiting for the engine is not one.
+
+- :meth:`~miney.Lua.run` says so when the code is too long instead of timing out. The
+  server silently drops anything over 640 KB, so a large snippet spent the full timeout
+  waiting for an answer that was never coming, then reported only *Timeout*.
+
+- Strings containing control characters no longer fail with a Lua syntax error.
+  ``lt.chat.send_to_all("hello\x00world")`` answered *invalid escape sequence* at anyone
+  who had never written a line of Lua, because the value was escaped the way JSON does
+  it and Lua has no ``\u`` escape. Affected every value on its way into Lua, so also
+  node names, player names and chat commands.
+
 v0.6.0
 ------
 

--- a/miney/__init__.py
+++ b/miney/__init__.py
@@ -12,6 +12,7 @@ from .luanti import Luanti, default_playername
 from .player import Player, PlayerIterable
 from .chat import Chat
 from .nodes import Nodes
+from .storage import Storage
 from .lua import Lua
 from .inventory import Inventory
 from .exceptions import (
@@ -62,5 +63,6 @@ __all__ = [
     "PlayerOffline",
     "Point",
     "SessionReconnected",
+    "Storage",
     "ToolIterable",
 ]

--- a/miney/__init__.py
+++ b/miney/__init__.py
@@ -2,7 +2,7 @@
 Miney is the python interface to Luanti
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # base classes
 from .point import Point

--- a/miney/__init__.py
+++ b/miney/__init__.py
@@ -2,7 +2,7 @@
 Miney is the python interface to Luanti
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 # base classes
 from .point import Point

--- a/miney/callback.py
+++ b/miney/callback.py
@@ -1,5 +1,5 @@
-from typing import TYPE_CHECKING, Callable, Optional, Dict, Any
-from .events import Event, create_event, ChatCommandEvent
+from typing import TYPE_CHECKING, Callable, List, Optional, Dict, Any, Tuple
+from .events import EVENT_FIELDS, Event, create_event, ChatCommandEvent
 import json
 import logging
 import queue
@@ -10,6 +10,26 @@ if TYPE_CHECKING:
     from .luanti import Luanti
 
 logger = logging.getLogger(__name__)
+
+
+def _is_comparable(value: Any) -> bool:
+    """
+    Whether a filter value is something an event field can be compared against.
+
+    A filter is answered with ``==`` on the server, so a value has to be a single
+    string, number or boolean, or a list of those. A position - the one table anybody
+    would try - can never equal anything and would silently match nothing.
+
+    :param value: What was written on the right-hand side of a filter field.
+    :return: ``True`` if the server can compare it.
+    """
+    scalars = (str, int, float, bool)
+    if isinstance(value, scalars):
+        return True
+    if isinstance(value, (list, tuple)):
+        return bool(value) and all(isinstance(one, scalars) for one in value)
+    return False
+
 
 class Callback:
     """
@@ -22,15 +42,25 @@ class Callback:
 
     You can access this class via the :attr:`~miney.Luanti.callbacks` property.
     """
-    SUPPORTED_EVENTS = {"chat_message", "player_leaves", "player_joins"}
+    #: Every event a handler can be registered for. The Lua mod knows the same names -
+    #: see ``EVENTS`` in ``mod_data/miney/callbacks.lua`` - and what each one carries is
+    #: the matching class in :mod:`miney.events`.
+    SUPPORTED_EVENTS = {
+        "chat_message", "player_leaves", "player_joins",
+        "node_dug", "node_placed", "node_punched",
+        "player_dies", "player_respawns", "player_punched", "player_hp_changed",
+    }
 
     def __init__(self, luanti: 'Luanti'):
         self.lt = luanti
         self._client = luanti.luanti
         self._client_id: str = str(uuid.uuid4())
+        #: Handlers by event name, then by the id the server knows them under.
         self._event_handlers: Dict[str, Dict[str, Callable[[Event], None]]] = {}
         self._command_handlers: Dict[str, Callable[[Event], None]] = {}
-        self._events_queue: "queue.Queue[Event]" = queue.Queue()
+        #: Each event as it arrived, together with the handler ids the mod addressed it
+        #: to. Chat commands bring None; they are looked up by command name instead.
+        self._events_queue: "queue.Queue[Tuple[Event, Optional[List[str]]]]" = queue.Queue()
         self._running = True
         self._dispatcher = threading.Thread(
             target=self._dispatch_loop, name="miney-callbacks-dispatcher", daemon=True
@@ -80,13 +110,23 @@ class Callback:
         """Deliver events to registered handlers asynchronously."""
         while self._running:
             try:
-                event = self._events_queue.get(timeout=0.5)
+                event, handler_ids = self._events_queue.get(timeout=0.5)
             except queue.Empty:
                 continue
             try:
                 # Use the Event object's attributes
                 if event.name in self.SUPPORTED_EVENTS:
-                    for cb in list((self._event_handlers.get(event.name) or {}).values()):
+                    # The mod applied the filters and named who the event is for, so
+                    # there is nothing left to decide here.
+                    registered = self._event_handlers.get(event.name) or {}
+                    for handler_id in handler_ids or ():
+                        cb = registered.get(handler_id)
+                        if cb is None:
+                            logger.debug(
+                                "Dropped a '%s' event for handler %s, which is gone.",
+                                event.name, handler_id,
+                            )
+                            continue
                         try:
                             cb(event)
                         except Exception as e:
@@ -95,7 +135,11 @@ class Callback:
                     # Access the command name directly from the event object
                     name = event.command_name
                     handler = self._command_handlers.get(name)
-                    if handler:
+                    # Asked against None, not for truth: a callable object may well be
+                    # falsy - an empty collector, a counter at zero - and `if handler`
+                    # would drop its events in silence for as long as it stays empty,
+                    # which is forever if it only fills up by being called.
+                    if handler is not None:
                         try:
                             handler(event)
                         except Exception as e:
@@ -134,7 +178,7 @@ class Callback:
         if "event" in data:
             # Create an Event object and put it in the queue
             event_obj = create_event(data)
-            self._events_queue.put(event_obj)
+            self._events_queue.put((event_obj, data.get("handlers")))
             logger.debug("Queued event %s for dispatch", event_obj.name)
             return
 
@@ -156,9 +200,53 @@ class Callback:
             def on_player_join(event: PlayerJoinsEvent):
                 print(f"Player {event.player_name} joined the game.")
 
+        Pass ``parameters`` when you want some of the events and not all of them. It names
+        fields of the event and the values worth waking up for; a list accepts any one of
+        them. The comparison happens on the server, so everything it rejects never travels
+        at all:
+
+        .. code-block:: python
+
+            @lt.callbacks.on("chat_message", {"sender_name": ["Steve", "Alex"]})
+            def on_friend_speaks(event):
+                print(f"{event.sender_name} said: {event.message}")
+
+        The fields you may filter on are the attributes of the matching event class -
+        :class:`~miney.events.ChatMessageEvent` has ``sender_name`` and ``message``.
+        Anything else raises, rather than matching nothing in silence. Every event and
+        what it carries is listed in :mod:`miney.events`.
+
+        A filter value is compared with ``==`` on the server, so it has to be a string,
+        a number, a boolean, or a list of those. A position cannot be filtered on -
+        ``{"pos": Point(1, 2, 3)}`` raises. Ask for the whole event and decide in your
+        own code:
+
+        .. code-block:: python
+
+            @lt.callbacks.on("node_dug")
+            def deep_dig(event):
+                if event.pos.y < 10:
+                    lt.chat.send_to_all(f"{event.player_name} is digging deep.")
+
+        Every field named has to match, and the filter belongs to the one handler you are
+        registering. Watching the same event twice for different things is fine, and each
+        handler only ever sees what it asked for:
+
+        .. code-block:: python
+
+            @lt.callbacks.on("chat_message", {"sender_name": "Steve"})
+            def steve_said_something(event):
+                print("Steve:", event.message)
+
+            @lt.callbacks.on("chat_message", {"message": "hello"})
+            def someone_said_hello(event):
+                lt.chat.send_to_all(f"Hello yourself, {event.sender_name}!")
+
         :param event: The name of the event to subscribe to.
-        :param parameters: Optional filters for the event subscription.
+        :param parameters: Event fields that have to match before the handler runs.
         :return: The decorator function.
+        :raises ValueError: If the event does not exist, or `parameters` names a field
+            the event does not carry.
         """
         def decorator(func: Callable[[Event], None]) -> Callable[[Event], None]:
             self.register(event, func, parameters)
@@ -215,8 +303,11 @@ class Callback:
 
         :param event: The name of the event to subscribe to.
         :param callback: The function to execute when the event occurs.
-        :param parameters: Optional filters for the event subscription.
+        :param parameters: Event fields that have to match before the handler runs, as
+            described on :meth:`~miney.callback.Callback.on`.
         :return: A unique token for this registration.
+        :raises ValueError: If the event does not exist, or `parameters` names a field
+            the event does not carry.
         """
         if event not in self.SUPPORTED_EVENTS:
             raise ValueError(
@@ -225,21 +316,45 @@ class Callback:
             )
         if not callable(callback):
             raise ValueError("callback must be callable")
+
+        # Checked here rather than only on the server: the mod answers asynchronously on
+        # the same channel the events arrive on, so a rejection over there would reach
+        # this process as a log line long after register() has returned. A misspelt field
+        # has to raise where it was typed.
+        if parameters:
+            unknown = sorted(set(parameters) - EVENT_FIELDS[event])
+            if unknown:
+                raise ValueError(
+                    f"Event '{event}' has no field '{unknown[0]}'. It sends: "
+                    f"{', '.join(sorted(EVENT_FIELDS[event]))}."
+                )
+            for name, wanted in parameters.items():
+                if not _is_comparable(wanted):
+                    raise ValueError(
+                        f"The filter for '{name}' has to be a string, a number, a "
+                        f"boolean or a list of those - a filter is answered with '==' "
+                        f"on the server. A position or any other structure cannot be "
+                        f"compared that way; let the event through and decide in your "
+                        f"own code, e.g. 'if event.pos.y < 10:'."
+                    )
+
+        # The token is the name this handler goes by on both sides. The mod stores the
+        # filter under it and puts it on every event it sends, so an arriving event
+        # already says which function it is for.
         token = str(uuid.uuid4())
         self._event_handlers.setdefault(event, {})[token] = callback
 
-        # Only register with server when this is the first handler for the event
-        if len(self._event_handlers[event]) == 1:
-            payload: Dict[str, Any] = {
-                "action": "register",
-                "events": [event],
-                "client_id": self._client_id,
-            }
-            if parameters:
-                payload["filters"] = parameters
-            self._send(payload)
-            logger.info("Registered event subscription for '%s'", event)
-
+        payload: Dict[str, Any] = {
+            "action": "register",
+            "events": [event],
+            "handler": token,
+            "client_id": self._client_id,
+        }
+        if parameters:
+            payload["filter"] = parameters
+        self._send(payload)
+        logger.info("Registered a handler for '%s'%s", event,
+                    " with a filter" if parameters else "")
         return token
 
     def unregister(self, event: str, token_or_callback: Any) -> None:
@@ -276,16 +391,22 @@ class Callback:
                 if cb is token_or_callback:
                     removed_key = t
                     break
-        if removed_key:
-            handlers.pop(removed_key, None)
-
-        if handlers and len(handlers) > 0:
+        if not removed_key:
             return
 
-        # If no handlers remain, unregister from server
-        self._event_handlers.pop(event, None)
-        self._send({"action": "unregister", "events": [event], "client_id": self._client_id})
-        logger.info("Unregistered event subscription for '%s'", event)
+        handlers.pop(removed_key, None)
+        if not handlers:
+            self._event_handlers.pop(event, None)
+
+        # Named, so the other handlers for this event keep theirs. The mod drops the
+        # subscription for the event once its last handler is gone.
+        self._send({
+            "action": "unregister",
+            "events": [event],
+            "handler": removed_key,
+            "client_id": self._client_id,
+        })
+        logger.info("Unregistered a handler for '%s'", event)
 
     def register_command(self, name: str, callback: Callable[[Event], None],
                          params: str = "", description: str = "",
@@ -368,7 +489,8 @@ class Callback:
                 self._send({"action": "unregister_chatcommand", "name": name, "client_id": self._client_id})
             self._command_handlers.clear()
 
-            # Unregister event subscriptions
+            # Unregister event subscriptions. No handler named, so the mod drops every
+            # one this connection left behind rather than them one at a time.
             for event in list(self._event_handlers.keys()):
                 self._send({"action": "unregister", "events": [event], "client_id": self._client_id})
             self._event_handlers.clear()

--- a/miney/chat.py
+++ b/miney/chat.py
@@ -43,8 +43,40 @@ class Chat:
             f"return minetest.chat_send_player({self.lt.lua.dumps(player)}, {self.lt.lua.dumps(message)})"
         )
 
-    def format_message(self, playername: str, message: str):
-        return self.lt.lua.run("return minetest.format_chat_message({}, {})".format(playername, message))
+    def format_message(self, playername: str, message: str) -> str:
+        """
+        Render a message the way the server would show it in the chat.
+
+        Applies the server's ``chat_message_format`` setting, so what comes back is the
+        line as a player would read it, decorations and all::
+
+            >>> lt.chat.format_message("Steve", "hello")
+            '<Steve> hello'
+
+        Useful when a script wants to log or forward chat that looks like chat, rather
+        than assembling the angle brackets by hand and getting them wrong on a server
+        that has configured a different format.
+
+        :param playername: Who the message is from.
+        :param message: What they said.
+        :return: The formatted line.
+        :raises TypeError: If either argument is not a string.
+        """
+        # Both values went into the Lua source unquoted until now, so every ordinary
+        # call built something like format_chat_message(Steve, hello world) - two
+        # undefined globals and a syntax error at the space. Nothing crossing into Lua
+        # may skip dumps(); this function was the one place in Miney that did.
+        if not isinstance(playername, str):
+            raise TypeError(
+                f"'playername' must be str, got {type(playername).__name__}."
+            )
+        if not isinstance(message, str):
+            raise TypeError(f"'message' must be str, got {type(message).__name__}.")
+
+        return self.lt.lua.run(
+            f"return minetest.format_chat_message("
+            f"{self.lt.lua.dumps(playername)}, {self.lt.lua.dumps(message)})"
+        )
 
     def register_command(
         self,

--- a/miney/cli.py
+++ b/miney/cli.py
@@ -230,6 +230,18 @@ def _resolve_world_and_game(
         # The one world already here, reused with its own game.
         return worlds[0]
 
+    if args.game is None and len(worlds) > 1:
+        # Several worlds and no hint: the one that is up is the one being worked in, and
+        # starting it again only opens a window onto it; with none up, the one worked in
+        # last. Reaching for the default-named world instead *creates a new world* beside
+        # the ones already here - a first start, a full map generation, a long wait, and
+        # a world nobody asked for. The game comes from the world itself rather than from
+        # its recorded state, because only world.mt decides what a world is.
+        by_name = dict(worlds)
+        chosen = manage.pick_world(paths) or manage.last_used_world(paths)
+        if chosen is not None and chosen.name in by_name:
+            return chosen.name, by_name[chosen.name]
+
     if args.game is not None:
         game = args.game
     elif not worlds and _stdin_is_interactive():
@@ -243,11 +255,11 @@ def _world_to_act_on(paths: manage.EnvPaths, args: argparse.Namespace) -> str:
     """
     The world a command that acts on an existing one (stop, logs) should target.
 
-    Same principle as :func:`_resolve_world_and_game`: with no ``--world`` given, a lone
-    existing world is the obvious target, so ``miney stop`` after ``miney start`` just
-    stops it, whatever game it uses, instead of reaching for a default-named world that
-    was never created. With no world or several, the game-derived default name is kept so
-    the command's own "does not exist" or naming message still fires.
+    Same rule as everywhere else - :func:`~miney.env.manage.pick_world` - so ``miney
+    stop`` after ``miney start`` stops what was started, whatever game it uses and
+    however many other worlds sit next to it on disk. Without an answer, the
+    game-derived default name is kept so the command's own "does not exist" message
+    still fires.
 
     :param paths: The environment.
     :param args: Parsed arguments.
@@ -255,10 +267,13 @@ def _world_to_act_on(paths: manage.EnvPaths, args: argparse.Namespace) -> str:
     """
     if args.world is not None:
         return args.world
+    chosen = manage.pick_world(paths)
+    if chosen is not None:
+        return chosen.name
     worlds = _worlds_on_disk(paths)
     if len(worlds) == 1:
         return worlds[0][0]
-    return args.game
+    return default_world_name(args.game) if args.game else args.game
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -369,6 +384,23 @@ def cmd_stop(args: argparse.Namespace) -> int:
             "Start a world first with: uv run miney start"
         )
         return 0
+
+    # Without --world and without an answer from pick_world, stopping "the" world would
+    # aim at a name nobody started - the user watches nothing happen and reaches for the
+    # task manager. Say what is there instead.
+    if args.world is None and manage.pick_world(paths) is None and len(list_states(paths)) > 1:
+        running = [one for one in list_states(paths)
+                   if manage.server_status(one) != "stopped"]
+        if not running:
+            print("No server is running. The worlds in this project:")
+            print(manage.describe_worlds(paths))
+            return 0
+        print("Several worlds are running. Say which one to stop:")
+        print(manage.describe_worlds(paths))
+        for one in running:
+            print(f"    uv run miney stop --world {one.name}")
+        return 1
+
     manage.stop(
         paths,
         _world_to_act_on(paths, args),

--- a/miney/env/manage.py
+++ b/miney/env/manage.py
@@ -321,6 +321,77 @@ def server_status(state: WorldState) -> str:
     return "stopped"
 
 
+def pick_world(paths: EnvPaths, port: int | None = None) -> WorldState | None:
+    """
+    The world a command that was not told which one means.
+
+    One rule, used by the command line and by :class:`~miney.luanti.Luanti` alike, so a
+    ``miney start`` and the script run after it cannot disagree about which world they
+    are talking about:
+
+    1. the world listening on ``port``, when a port was named;
+    2. the only world there is;
+    3. the only world whose server is **running**.
+
+    Rule 3 is what makes a second world harmless. Creating one used to take the answer
+    away from every unnamed command in the project - a script that had worked all day
+    stopped with "Several worlds exist" and no way to say which, even after everything
+    was shut down again. A world that is up is the one being worked in.
+
+    :param paths: The environment to look in.
+    :param port: A port that was asked for explicitly, or None.
+    :return: The world to use, or None when it is genuinely ambiguous - several worlds
+        and none, or more than one, running. Report that with :func:`describe_worlds`.
+    """
+    states = list_states(paths)
+    if not states:
+        return None
+    if port is not None:
+        on_that_port = [state for state in states if state.port == port]
+        if len(on_that_port) == 1:
+            return on_that_port[0]
+    if len(states) == 1:
+        return states[0]
+    running = [state for state in states if is_server_up(state)]
+    if len(running) == 1:
+        return running[0]
+    return None
+
+
+def describe_worlds(paths: EnvPaths) -> str:
+    """
+    Every world and what it is doing, as indented lines for an error message.
+
+    :param paths: The environment to look in.
+    :return: One line per world: its name, its status and its port.
+    """
+    lines = []
+    for state in sorted(list_states(paths), key=lambda one: one.name.lower()):
+        lines.append(f"    {state.name:<16} {server_status(state):<9} port {state.port}")
+    return "\n".join(lines)
+
+
+def last_used_world(paths: EnvPaths) -> WorldState | None:
+    """
+    The world whose state was written most recently - the one worked in last.
+
+    Only used to suggest a name in a message. Suggesting the first world alphabetically
+    once told somebody to use the throwaway world a test had left behind, over the world
+    they had been building in all evening.
+
+    :param paths: The environment to look in.
+    :return: The most recently touched world, or None if there are none.
+    """
+    def touched(state: WorldState) -> float:
+        try:
+            return paths.state_file(state.name).stat().st_mtime
+        except OSError:
+            return 0.0
+
+    states = list_states(paths)
+    return max(states, key=touched) if states else None
+
+
 def _worlds_without_state(paths: EnvPaths, known: set[str]) -> dict[str, str]:
     """
     Worlds that exist on disk but are not among the names already known from state.
@@ -408,6 +479,7 @@ def wait_until_up(
     sleep: Callable[[float], None] = time.sleep,
     clock: Callable[[], float] = time.monotonic,
     report: Reporter | None = None,
+    first_start: bool = False,
 ) -> None:
     """
     Wait until a freshly started server accepts connections.
@@ -446,11 +518,15 @@ def wait_until_up(
                 f"Read the end of it with: uv run miney logs --world {state.name}"
             )
         if not announced:
+            # Two different waits, and saying "generating the map" for a world that has
+            # one is how a normal 20-second VoxeLibre start reads like something going
+            # wrong. VoxeLibre loads a few hundred mods every time; that is the wait.
+            why = ("generating its map, which only happens once" if first_start
+                   else "loading the game's mods")
             _say(
                 report,
                 f"Waiting up to {timeout:g} seconds for the Luanti server for "
-                f"'{state.name}' to finish starting. The first start of a world "
-                "generates the map and can take a while.",
+                f"'{state.name}' to finish starting - it is {why}.",
             )
             announced = True
         sleep(interval)
@@ -888,6 +964,14 @@ def ensure_world(
     ensure_game(paths, game, report=report)
     _preload_games(paths, exclude=game, report=report)
     if existing is None:
+        # Said before the world is written, because what follows it is a first start:
+        # the server generates a map and answers minutes later. Without this line that
+        # wait looks like Miney hanging, and the world it was spent on is a surprise.
+        _say(
+            report,
+            f"Creating a new world '{world}' with {contentdb.game_label(game)}. "
+            "Generating its map takes a while the first time.",
+        )
         write_world_mt(world_dir, game)
     write_config(paths.config_file)
     ensure_client_password(paths.client_pw)
@@ -1170,6 +1254,11 @@ def start(
     :raises MineyRunError: If the world, Luanti, the port or the processes could not be
         made ready. Every message names a command that gets the user further.
     """
+    # Asked before ensure_world(), which creates the world and would answer "yes" to
+    # every start afterwards. Only used to explain the wait: a first start generates a
+    # map, every later one only loads the game's mods.
+    first_start = read_world_gameid(paths.world_dir(world)) is None
+
     # ensure_world() completes the environment - downloading a missing Luanti first,
     # then a missing game - and hands back the install to launch.
     install = ensure_world(paths, world, game, report=report)
@@ -1232,6 +1321,7 @@ def start(
         sleep=sleep,
         clock=clock,
         report=report,
+        first_start=first_start,
     )
 
     if with_client:

--- a/miney/events.py
+++ b/miney/events.py
@@ -3,6 +3,8 @@ import time
 from typing import Any, Dict, Optional, Type
 from datetime import datetime
 
+from .point import Point
+
 
 @dataclass(frozen=True)
 class Event:
@@ -49,6 +51,186 @@ class ChatCommandEvent(Event):
 
 
 @dataclass(frozen=True)
+class NodeDugEvent(Event):
+    """
+    A block was dug away, sent once it is gone.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("node_dug")
+        def cave_in(event):
+            print(f"{event.player_name} dug {event.node_name} at {event.pos}")
+
+    A block removed by a mod, by falling gravel or by an explosion has no digger, and
+    ``player_name`` is then an empty string.
+
+    Blocks a script removes do not send this event: neither :meth:`~miney.Nodes.fill`
+    nor :meth:`~miney.Nodes.set` digs anything, they write the map directly. This is
+    about what the people in the world do.
+    """
+    name: str = field(init=False, default="node_dug")
+    #: Where the block was, as a :class:`~miney.Point`.
+    pos: Point
+    #: What was dug, e.g. ``"mcl_core:dirt"``.
+    node_name: str
+    #: Who dug it, or ``""`` if nobody did.
+    player_name: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class NodePlacedEvent(Event):
+    """
+    A block was placed, sent once it is there.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("node_placed", {"node_name": "mcl_core:dirt"})
+        def no_dirt_towers(event):
+            lt.chat.send_to_all(f"{event.player_name} placed dirt at {event.pos}")
+
+    Sent when somebody *places* a block. Blocks written by a script are not placed but
+    set - :meth:`~miney.Nodes.set` and :meth:`~miney.Nodes.fill` send nothing - so a
+    handler that builds something cannot set itself off.
+    """
+    name: str = field(init=False, default="node_placed")
+    #: Where it went, as a :class:`~miney.Point`.
+    pos: Point
+    #: What was placed.
+    node_name: str
+    #: Who placed it, or ``""`` for a block a mod placed.
+    player_name: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class NodePunchedEvent(Event):
+    """
+    A block was hit without being dug - one left click, not a finished dig.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("node_punched")
+        def knock_knock(event):
+            lt.chat.send_to_player(event.player_name, f"That is a {event.node_name}.")
+
+    Hitting a block a player *can* dig sends this first and
+    :class:`~miney.events.NodeDugEvent` a moment later. A block nobody can dig - bedrock -
+    only ever sends this one.
+    """
+    name: str = field(init=False, default="node_punched")
+    #: Which block was hit, as a :class:`~miney.Point`.
+    pos: Point
+    #: What was hit.
+    node_name: str
+    #: Who hit it, or ``""``.
+    player_name: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class PlayerDiesEvent(Event):
+    """
+    A player died.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("player_dies")
+        def condolences(event):
+            lt.chat.send_to_all(f"{event.player_name} died of {event.reason}.")
+
+    The player is dead when this arrives and stays where they died until they respawn -
+    :class:`~miney.events.PlayerRespawnsEvent` is where a script sends them somewhere.
+    """
+    name: str = field(init=False, default="player_dies")
+    #: Who died.
+    player_name: str
+    #: What killed them, as Luanti names it: ``"punch"``, ``"fall"``, ``"node_damage"``,
+    #: ``"drown"``, ``"set_hp"``, or ``"unknown"``.
+    reason: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class PlayerRespawnsEvent(Event):
+    """
+    A player is coming back, sent before the game decides where to put them.
+
+    .. code-block:: python
+
+        from miney import Point
+
+        @lt.callbacks.on("player_respawns")
+        def home_again(event):
+            lt.players[event.player_name].move(destination=Point(0, 20, 0))
+
+    The move has to wait for this event rather than for
+    :class:`~miney.events.PlayerDiesEvent`: the game repositions the player after this
+    callback, so anything a script does at death time is overwritten a moment later.
+    """
+    name: str = field(init=False, default="player_respawns")
+    #: Who is respawning.
+    player_name: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class PlayerPunchedEvent(Event):
+    """
+    A player was hit by someone or something.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("player_punched")
+        def bodyguard(event):
+            if event.hitter_name:
+                lt.chat.send_to_all(f"{event.hitter_name} hit {event.player_name}!")
+
+    Sent for the notification only - the hit lands either way, and the damage is what
+    the engine calculated before any armour the game applies afterwards. A mob or an
+    arrow leaves ``hitter_name`` empty, because only players have names.
+    """
+    name: str = field(init=False, default="player_punched")
+    #: Who was hit.
+    player_name: str
+    #: Who hit them, or ``""`` when it was not a player.
+    hitter_name: str
+    #: The damage the engine calculated, in half hearts.
+    damage: float
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
+class PlayerHpChangedEvent(Event):
+    """
+    A player lost or gained health.
+
+    .. code-block:: python
+
+        @lt.callbacks.on("player_hp_changed")
+        def nurse(event):
+            if event.hp < 6:
+                lt.chat.send_to_player(event.player_name, "Careful - you are nearly dead.")
+
+    Damage sends a negative ``hp_change``, healing a positive one. Setting
+    :attr:`player.hp <miney.Player.hp>` from a script sends one too, with ``reason``
+    ``"set_hp"``. A player who is already dead takes no more damage and sends nothing;
+    healing someone who is already full does send an event.
+    """
+    name: str = field(init=False, default="player_hp_changed")
+    #: Whose health changed.
+    player_name: str
+    #: How much, negative for damage.
+    hp_change: float
+    #: What they have left afterwards, out of 20 in most games.
+    hp: float
+    #: Why, as Luanti names it: ``"punch"``, ``"fall"``, ``"node_damage"``, ``"drown"``,
+    #: ``"set_hp"``, or ``"unknown"``.
+    reason: str
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True)
 class GenericEvent(Event):
     """An event for which no specific type is defined."""
     raw_payload: Dict[str, Any]
@@ -61,6 +243,26 @@ _EVENT_CLASS_MAP: Dict[str, Type[Event]] = {
     "player_leaves": PlayerLeavesEvent,
     "player_joins": PlayerJoinsEvent,
     "chatcommand": ChatCommandEvent,
+    "node_dug": NodeDugEvent,
+    "node_placed": NodePlacedEvent,
+    "node_punched": NodePunchedEvent,
+    "player_dies": PlayerDiesEvent,
+    "player_respawns": PlayerRespawnsEvent,
+    "player_punched": PlayerPunchedEvent,
+    "player_hp_changed": PlayerHpChangedEvent,
+}
+
+#: What each event carries, and therefore what a subscription filter may match on.
+#:
+#: Read off the dataclasses rather than written out again, so it cannot drift away from
+#: what a handler actually receives. ``client_id`` and ``timestamp`` are dropped because
+#: they belong to the envelope around the event, not to the thing that happened.
+EVENT_FIELDS: Dict[str, frozenset] = {
+    name: frozenset(
+        f.name for f in fields(cls)
+        if f.init and f.name not in ("client_id", "timestamp")
+    )
+    for name, cls in _EVENT_CLASS_MAP.items()
 }
 
 
@@ -85,21 +287,24 @@ def create_event(raw_event: Dict[str, Any]) -> Event:
     if "ts" in raw_event:
         common_args["timestamp"] = raw_event["ts"]
 
+    # The mod names the payload fields exactly like the attributes below, so the payload
+    # goes into the constructor as it arrives. It used to send 'name' for the sender, the
+    # player and the command alike, and every one of those needed its own renaming branch
+    # here - see MOD_API 3 in mod_data/miney/init.lua.
     event_args = raw_payload.copy()
     event_args.update(common_args)
-
-    # Resolve ambiguous 'name' field from payload by renaming it
-    if event_name == "chat_message":
-        event_args["sender_name"] = event_args.pop("name", "")
-    elif event_name in ("player_joins", "player_leaves"):
-        event_args["player_name"] = event_args.pop("name", "")
-    elif event_name == "chatcommand":
-        event_args["command_name"] = event_args.pop("name", "")
 
     # Handle special data conversion for player_joins
     if event_name == "player_joins":
         last_login_ts = event_args.get("last_login")
         event_args["last_login"] = datetime.fromtimestamp(last_login_ts) if last_login_ts else None
+
+    # A position travels as three numbers and arrives as a Point, so an event can be
+    # handed straight to nodes.get(), nodes.set() or player.move() without unpacking it.
+    position = event_args.get("pos")
+    if isinstance(position, dict):
+        event_args["pos"] = Point(position.get("x", 0), position.get("y", 0),
+                                  position.get("z", 0))
 
     if event_class:
         # Filter args to only those expected by the constructor to avoid TypeError

--- a/miney/exceptions.py
+++ b/miney/exceptions.py
@@ -35,6 +35,11 @@ class LuaResultTimeout(Exception):
 class DataError(Exception):
     """
     Malformed data received.
+
+    The server answered, but not with something Miney could make sense of - for
+    instance a region read that describes a different number of nodes than were asked
+    for. It means the two halves disagree, so the usual cause is a mod that is not the
+    one this Miney ships with.
     """
     pass
 
@@ -54,13 +59,34 @@ class SessionReconnected(Exception):
 
 
 # Player exceptions
-class PlayerNotFoundError(Exception):
+class PlayerNotFoundError(IndexError):
+    """
+    There is no player of that name.
+
+    Raised by ``lt.players["Name"]`` and by :class:`~miney.player.Player` itself. The
+    message lists who *is* online, because that is nearly always the next question::
+
+        >>> lt.players["Steev"]
+        PlayerNotFoundError: There is no player 'Steev'. Online: 'Steve', 'Ana'.
+
+    It stays a subclass of ``IndexError``, which is what an unknown name used to raise.
+    """
     pass
 
 
 class PlayerOffline(Exception):
+    """
+    The player exists, but is not currently connected.
+
+    Their account is known to the server - Miney can read their privileges - but
+    anything that needs them to be in the world, such as
+    :attr:`~miney.Player.position`, has nothing to work with.
+    """
     pass
 
 
 class NoValidPosition(Exception):
+    """
+    A position was asked for that does not exist in the world.
+    """
     pass

--- a/miney/inventory.py
+++ b/miney/inventory.py
@@ -7,11 +7,55 @@ if TYPE_CHECKING:
 class Inventory:
     """
     Inventories are places to store items, like Chests or player inventories.
+
+    You do not create this yourself - you get one from
+    :attr:`~miney.Player.inventory` or :attr:`~miney.node.Node.inventory`.
     """
 
     def __init__(self, luanti: 'Luanti', parent: object):
         self.lt = luanti
         self.parent = parent
+
+    def _no_owner(self, action: str) -> TypeError:
+        """
+        Build the error for an inventory that belongs to neither a player nor a node.
+
+        Every method here has to ask what it is attached to, because the Lua call
+        differs. Without this they returned ``None`` or ``[]`` for anything else, so a
+        wrongly built Inventory looked like an empty one.
+
+        :param action: What was attempted, for the message.
+        :return: The exception to raise.
+        """
+        return TypeError(
+            f"Cannot {action}: this inventory belongs to a "
+            f"{type(self.parent).__name__}, and only players and nodes have one. Get "
+            f"an inventory from lt.players['Name'].inventory or from "
+            f"lt.nodes.get(point).inventory."
+        )
+
+    def _getter(self, action: str) -> str:
+        """
+        Build the Lua that fetches this inventory, whoever it belongs to.
+
+        A player inventory is found by name and a node inventory by position, so every
+        method here needs the same two-way decision. It lives in one place so it is
+        also quoted in one place: the player name goes through
+        :meth:`~miney.Lua.dumps` rather than into the Lua source as-is.
+
+        :param action: What was attempted, for the error message.
+        :return: A Lua expression evaluating to the inventory, or ``nil``.
+        :raises TypeError: If this inventory belongs to neither a player nor a node.
+        """
+        from .node import Node
+        if isinstance(self.parent, Player):
+            spec = {"type": "player", "name": self.parent.name}
+        elif isinstance(self.parent, Node):
+            spec = {"type": "node",
+                    "pos": {"x": self.parent.x, "y": self.parent.y, "z": self.parent.z}}
+        else:
+            raise self._no_owner(action)
+        return f"minetest.get_inventory({self.lt.lua.dumps(spec)})"
 
     def add(self, item: str, amount: int = 1) -> None:
         """
@@ -20,28 +64,15 @@ class Inventory:
         :param item: item type
         :param amount: item amount
         :return: None
+        :raises TypeError: If this inventory belongs to neither a player nor a node
         """
-        from .node import Node
-        if isinstance(self.parent, Player):
-            self.lt.lua.run(
-                f"minetest.get_inventory("
-                f"{{type = \"player\", name = \"{self.parent.name}\"}}"
-                f"):add_item(\"main\", ItemStack(\"{item} {amount}\"))"
-            )
-        elif isinstance(self.parent, Node):
-            pos_str = f"{{x={self.parent.x}, y={self.parent.y}, z={self.parent.z}}}"
-            self.lt.lua.run(
-                f'local pos = {pos_str}\n'
-                f'local inv = minetest.get_inventory({{type = "node", pos = pos}})\n'
-                f'if inv then\n'
-                f'    local list_name = "main"\n'
-                f'    local lists = inv:get_lists()\n'
-                f'    if lists and #lists > 0 then\n'
-                f'        list_name = lists[1]\n'
-                f'    end\n'
-                f'    inv:add_item(list_name, ItemStack("{item} {amount}"))\n'
-                f'end'
-            )
+        getter = self._getter(f"add {amount}x '{item}'")
+        self.lt.lua.run(
+            f'local inv = {getter}\n'
+            f'if inv then\n'
+            f'    inv:add_item("main", ItemStack({self.lt.lua.dumps(f"{item} {amount}")}))\n'
+            f'end'
+        )
 
     def remove(self, item: str, amount: int = 1) -> None:
         """
@@ -50,29 +81,28 @@ class Inventory:
         :param item: item type
         :param amount: item amount
         :return: None
+        :raises TypeError: If this inventory belongs to neither a player nor a node
         """
-        from .node import Node
-        if isinstance(self.parent, Player):
-            self.lt.lua.run(
-                f"minetest.get_inventory({{type = \"player\", "
-                f"name = \"{self.parent.name}\"}}):remove_item(\"main\", ItemStack(\"{item} {amount}\"))")
-        elif isinstance(self.parent, Node):
-            pos_str = f"{{x={self.parent.x}, y={self.parent.y}, z={self.parent.z}}}"
-            self.lt.lua.run(
-                f'local pos = {pos_str}\n'
-                f'local inv = minetest.get_inventory({{type = "node", pos = pos}})\n'
-                f'if inv then\n'
-                f'    inv:remove_item("main", ItemStack("{item} {amount}"))\n'
-                f'end'
-            )
+        getter = self._getter(f"remove {amount}x '{item}'")
+        self.lt.lua.run(
+            f'local inv = {getter}\n'
+            f'if inv then\n'
+            f'    inv:remove_item("main", ItemStack({self.lt.lua.dumps(f"{item} {amount}")}))\n'
+            f'end'
+        )
 
     def get_lists(self) -> list[str]:
         """
         Get the names of all available inventory lists.
 
-        :return: A list of inventory list names (e.g., ["main", "craft"]).
+        :return: A list of inventory list names (e.g., ["main", "craft"]), empty if
+            there are none.
+        :raises TypeError: If this inventory belongs to neither a player nor a node
         """
-        lua_code = """
+        getter = self._getter("list the inventory lists")
+        # `or []`: an empty Lua table arrives as None, and a caller looping over the
+        # answer should not have to know that.
+        return self.lt.lua.run(f"""
             local inv = {getter}
             if not inv then return {{}} end
             local lists = inv:get_lists()
@@ -82,45 +112,31 @@ class Inventory:
                 table.insert(names, name)
             end
             return names
-        """
-        from .node import Node
-        if isinstance(self.parent, Player):
-            getter = f'minetest.get_inventory({{type = "player", name = "{self.parent.name}"}})'
-            return self.lt.lua.run(lua_code.format(getter=getter))
-        elif isinstance(self.parent, Node):
-            pos_str = f"{{x={self.parent.x}, y={self.parent.y}, z={self.parent.z}}}"
-            getter = f'minetest.get_inventory({{type = "node", pos = {pos_str}}})'
-            return self.lt.lua.run(lua_code.format(getter=getter))
-        return []
+        """) or []
 
-    def get_list(self, name: str = "main") -> list[str | None]:
+    def get_list(self, name: str = "main") -> list[str]:
         """
         Get the content of an inventory list.
 
+        Only the occupied slots come back, as strings like ``"mcl_core:apple 5"`` - the
+        empty ones are left out rather than filling the answer with placeholders.
+
         :param name: The name of the list to get (e.g., "main").
-        :return: A list of item strings. Empty slots are represented by None.
+        :return: A list of item strings, empty if the inventory list is.
+        :raises TypeError: If this inventory belongs to neither a player nor a node
         """
-        lua_code = """
+        getter = self._getter(f"read the inventory list '{name}'")
+        # `or []`: an empty Lua table arrives as None, and an empty chest is normal.
+        return self.lt.lua.run(f"""
             local inv = {getter}
             if not inv then return {{}} end
-            local list = inv:get_list("{list_name}")
+            local list = inv:get_list({self.lt.lua.dumps(name)})
             if not list then return {{}} end
             local out = {{}}
             for _, stack in ipairs(list) do
                 if not stack:is_empty() then
                     table.insert(out, stack:to_string())
-                else
-                    table.insert(out, nil)
                 end
             end
             return out
-        """
-        from .node import Node
-        if isinstance(self.parent, Player):
-            getter = f'minetest.get_inventory({{type = "player", name = "{self.parent.name}"}})'
-            return self.lt.lua.run(lua_code.format(getter=getter, list_name=name))
-        elif isinstance(self.parent, Node):
-            pos_str = f"{{x={self.parent.x}, y={self.parent.y}, z={self.parent.z}}}"
-            getter = f'minetest.get_inventory({{type = "node", pos = {pos_str}}})'
-            return self.lt.lua.run(lua_code.format(getter=getter, list_name=name))
-        return []
+        """) or []

--- a/miney/lua.py
+++ b/miney/lua.py
@@ -22,6 +22,67 @@ logger = logging.getLogger(__name__)
 
 LUA_IDENTIFIER_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+#: How much a formspec submit may carry, names and values of every field added up.
+#: The server drops anything larger without a word to the client
+#: (``pkt_read_formspec_fields`` in ``serverpackethandler.cpp``), so the request has to
+#: be measured here or it ends as a timeout with no reason given.
+FORMSPEC_FIELD_LIMIT = 640 * 1024
+
+#: The oldest Lua mod this version of Miney can talk to. The mod sends its own number
+#: with every answer (``MOD_API`` in ``mod_data/miney/init.lua``); anything lower, or a
+#: mod old enough not to send one at all, is refused with an error that says how to
+#: update instead of failing later on a name the mod does not have yet.
+#:
+#: This is not the Miney version and does not move with a release. Raise it only
+#: together with ``MOD_API``, when the two halves stop understanding each other.
+REQUIRED_MOD_API = 1
+
+#: Lua's own escapes for the characters that have one. Everything else below a space
+#: becomes a numeric escape - see :func:`_lua_string`.
+_LUA_ESCAPES = {
+    '"': '\\"',
+    "\\": "\\\\",
+    "\a": "\\a",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\v": "\\v",
+}
+
+
+def _lua_string(value: str) -> str:
+    """
+    Quote a Python string as a Lua string literal.
+
+    Written by hand rather than with :func:`json.dumps`, which looks close enough to
+    Lua but escapes control characters as ``\\u0000``. Lua has no ``\\u`` escape, so
+    the server answered ``chat.send_to_all("hello\\x00world")`` with *invalid escape
+    sequence* - a Lua syntax error, at somebody who never wrote any Lua.
+
+    Control characters also may not travel unescaped: the server runs every incoming
+    formspec field through ``sanitize_untrusted()``, which truncates the code at the
+    first NUL and drops carriage returns.
+
+    Numeric escapes are always padded to three digits. ``"\\7"`` followed by a literal
+    ``8`` would otherwise read as ``"\\78"``.
+
+    :param value: The string to quote.
+    :return: A Lua string literal, quotes included.
+    """
+    out = ['"']
+    for character in value:
+        escape = _LUA_ESCAPES.get(character)
+        if escape is not None:
+            out.append(escape)
+        elif character < " " or character == "\x7f":
+            out.append(f"\\{ord(character):03d}")
+        else:
+            out.append(character)
+    out.append('"')
+    return "".join(out)
+
 
 class Lua:
     """
@@ -36,6 +97,9 @@ class Lua:
     def __init__(self, luanti: 'LuantiClient'):
         self.luanti = luanti
         self.form_ready: bool = False
+        #: Which contract version the Lua mod on the server answered with, or None while
+        #: nothing has answered yet. Compared against ``REQUIRED_MOD_API``.
+        self.mod_api: int | None = None
         self.pending_lua_results: dict[str, dict | None] = {}
         self._register_handlers()
 
@@ -71,6 +135,11 @@ class Lua:
             if response_data is None:
                 logger.debug("Received null JSON response. Likely an initial form. Ignoring.")
                 return
+
+            # Read before anything else returns early: the warm-up answer carries this
+            # and nothing else, and it is what run() waits for.
+            if isinstance(response_data, dict) and "mod_api" in response_data:
+                self.mod_api = response_data["mod_api"]
 
             execution_id = response_data.get("execution_id")
 
@@ -146,6 +215,31 @@ class Lua:
         s = s.replace(r'\\', '\\')
         return s
 
+    def _check_mod_api(self) -> None:
+        """
+        Refuse a Lua mod that is older than this version of Miney.
+
+        Miney ships the mod it needs, so the two halves normally move together. They
+        come apart when the mod was installed by hand or from ContentDB and only the
+        Python side was updated. Without this check the symptom is whatever the new
+        half asks for first - ``attempt to index global 'storage' (a nil value)`` -
+        which reads as a bug in the user's own code.
+
+        :raises LuantiConnectionError: If the mod is too old, or too old to say.
+        """
+        if self.mod_api is not None and self.mod_api >= REQUIRED_MOD_API:
+            return
+
+        found = "did not say which version it is" if self.mod_api is None \
+            else f"speaks version {self.mod_api}"
+        raise LuantiConnectionError(
+            f"The 'miney' mod on the server is too old for this version of Miney: it "
+            f"{found}, and version {REQUIRED_MOD_API} is needed. Update the mod on the "
+            f"server. For a world you started with the 'miney' command, that is "
+            f"'miney upgrade'; for somebody else's server, the admin updates it from "
+            f"https://content.luanti.org/packages/Miney/miney/"
+        )
+
     def send_command(self, command: str) -> bool:
         """
         Sends a chat command prefixed with /miney to the server.
@@ -158,6 +252,37 @@ class Lua:
     def run(self, lua_code: str, timeout: int = 10, execution_id: str = None) -> Any:
         """
         Execute Lua code on the server and return the result.
+
+        The code runs in a sandbox that lives as long as your connection, so a global
+        you assign in one call is still there in the next one::
+
+            lt.lua.run("counter = (counter or 0) + 1")
+            lt.lua.run("counter = (counter or 0) + 1")
+            print(lt.lua.run("return counter"))  # 2
+
+        The names are yours alone - another script on the same server has its own set -
+        and they are gone once you disconnect. Assigning a name the sandbox already
+        provides (``minetest = 5``) hides it for your connection only.
+
+        The sandbox has no ``_G``. ``_G.counter = 1`` raises *attempt to index global
+        '_G' (a nil value)* - assign the bare name instead, as above.
+
+        .. warning::
+
+           The sandbox keeps scripts from tripping over each other. It is not a security
+           boundary. Everything Luanti gives a mod is reachable from here, so granting
+           somebody the ``miney`` privilege on your server is granting them the server.
+
+        To keep something for longer than that, write it to ``storage``, the world's own
+        key-value store::
+
+            lt.lua.run("storage:set_string('base', '10,20,30')")
+            print(lt.lua.run("return storage:get_string('base')"))  # '10,20,30'
+
+        It lives in the world directory and survives a server restart, which is also the
+        trade-off: every script on that world shares one set of keys. It is Luanti's
+        ``StorageRef``, so ``set_string``, ``get_string``, ``set_int``, ``get_int``,
+        ``to_table`` and ``from_table`` all work.
 
         :param lua_code: The Lua code to execute.
         :param timeout: Maximum wait time in seconds for the result.
@@ -179,20 +304,24 @@ class Lua:
             logger.warning(f"Cannot execute Lua code: not fully connected (state: {self.luanti.state.state})")
             raise LuantiConnectionError("Not fully connected to the server")
 
-        # Ensure the code form is ready before proceeding.
-        if not self.form_ready:
+        # Ensure the code form is ready before proceeding. The same answer carries the
+        # mod's API number, so ask again when only the form is known - that happens when
+        # a callback event arrived before the first run().
+        if not self.form_ready or self.mod_api is None:
             logger.debug("Code form is not ready, requesting it now...")
             self.send_command("form")
 
             # Wait for the form to become ready
             form_timeout = time.time() + 5
-            while not self.form_ready and time.time() < form_timeout:
+            while (not self.form_ready or self.mod_api is None) and time.time() < form_timeout:
                 time.sleep(0.1)
 
             if not self.form_ready:
                 logger.error("Failed to receive code form from the server after request.")
                 raise LuantiConnectionError("Cannot execute Lua code: 'miney:code_form' is not available. "
                                       "Ensure the 'miney' mod is installed on the server.")
+
+        self._check_mod_api()
 
         # Generate a unique ID if none was provided
         if execution_id is None:
@@ -208,6 +337,18 @@ class Lua:
             "execute": "true",
             "execution_id": execution_id
         }
+
+        payload_size = sum(
+            len(name.encode()) + len(value.encode()) for name, value in fields.items()
+        )
+        if payload_size >= FORMSPEC_FIELD_LIMIT:
+            self.pending_lua_results.pop(execution_id, None)
+            raise LuaError(
+                f"This Lua code is too long to send: {payload_size} bytes, and the "
+                f"server accepts less than {FORMSPEC_FIELD_LIMIT}. It would be dropped "
+                f"on arrival without an answer. Send it in several smaller calls, or "
+                f"replace a long list of values in the code with a loop that builds it."
+            )
 
         try:
             self.luanti.send_formspec_response("miney:code_form", fields)
@@ -331,9 +472,7 @@ class Lua:
         if isinstance(data, (int, float)):
             return str(data)
         if isinstance(data, str):
-            # json.dumps is a safe way to create a quoted and escaped string
-            # that is compatible with Lua's string literal format.
-            return json.dumps(data, ensure_ascii=False)
+            return _lua_string(data)
         # Treat Python tuples like Lua arrays as well
         if isinstance(data, (list, tuple)):
             return "{" + ", ".join(self.dumps(item) for item in data) + "}"

--- a/miney/lua.py
+++ b/miney/lua.py
@@ -35,7 +35,7 @@ FORMSPEC_FIELD_LIMIT = 640 * 1024
 #:
 #: This is not the Miney version and does not move with a release. Raise it only
 #: together with ``MOD_API``, when the two halves stop understanding each other.
-REQUIRED_MOD_API = 1
+REQUIRED_MOD_API = 4
 
 #: Lua's own escapes for the characters that have one. Everything else below a space
 #: becomes a numeric escape - see :func:`_lua_string`.

--- a/miney/luanti.py
+++ b/miney/luanti.py
@@ -1,4 +1,6 @@
+import atexit
 import logging
+import weakref
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Dict, Optional, Callable
@@ -41,13 +43,20 @@ def _log_progress(progress: manage.Progress) -> None:
         logger.info(progress.message)
 
 
-def _resolve_env_world(world: str | None) -> tuple[EnvPaths, WorldState] | None:
+def _resolve_env_world(world: str | None,
+                       port: int | None = None) -> tuple[EnvPaths, WorldState] | None:
     """
     Find the environment and the world to use inside it.
 
+    With no world named, this follows :func:`~miney.env.manage.pick_world`: the world on
+    the port that was asked for, the only world there is, or the only one that is
+    running. A script therefore keeps working when a second world appears next to the
+    one it uses, as long as that one is the one that is up.
+
     :param world: Explicitly requested world name, or None.
+    :param port: Explicitly requested port, or None.
     :return: The environment and the world's state, or None if there is no environment.
-    :raises MineyRunError: If no world matches, or if several exist and none was named.
+    :raises MineyRunError: If no world matches, or if it cannot be told which is meant.
     """
     paths = find_env()
     if paths is None:
@@ -68,13 +77,61 @@ def _resolve_env_world(world: str | None) -> tuple[EnvPaths, WorldState] | None:
         raise MineyRunError(
             f"{paths.root} has no world yet. Create one with: uv run miney start"
         )
-    if len(states) > 1:
-        names = ", ".join(s.name for s in states)
-        raise MineyRunError(
-            f"Several worlds exist ({names}). Say which one to use:\n"
-            f"    miney.Luanti(world=\"{states[0].name}\")"
-        )
-    return paths, states[0]
+
+    chosen = manage.pick_world(paths, port=port)
+    if chosen is not None:
+        return paths, chosen
+
+    # Ambiguous, and which kind of ambiguous decides what to suggest: with several
+    # servers up, naming one is the only way out; with none up, starting one answers it
+    # for every command afterwards.
+    running = [state for state in states if manage.is_server_up(state)]
+    suggestion = (running[0] if running else manage.last_used_world(paths) or states[0])
+    if running:
+        opening = "Several worlds are running, so Miney cannot tell which one you mean:"
+        closing = ""
+    else:
+        opening = ("Several worlds exist and none of them is running, so Miney cannot "
+                   "tell which one you mean:")
+        closing = ("\nOr start one - everything after that follows the world that is "
+                   f"up:\n    uv run miney start --world {suggestion.name}")
+    raise MineyRunError(
+        f"{opening}\n"
+        f"{manage.describe_worlds(paths)}\n"
+        f"Say which one:\n"
+        f'    miney.Luanti(world="{suggestion.name}"){closing}'
+    )
+
+
+def _make_atexit_disconnect(luanti_ref: "weakref.ReferenceType[Luanti]") -> Callable[[], None]:
+    """
+    Build the handler that disconnects one :class:`Luanti` when the script ends.
+
+    ``__del__`` cannot do this. Every namespace hanging off ``Luanti`` - ``Chat``,
+    ``Nodes``, ``Lua``, ``Storage``, ``Callback`` - keeps a reference back to it, so the
+    object is only ever reachable in a cycle and only the cyclic collector could free
+    it. CPython does not promise to run that collector at interpreter shutdown, and in
+    practice it does not: a script that ends without ``with`` never disconnected at all.
+    The server then held the session until it timed out, and running the same script
+    again a moment later was refused with *"Another client is already connected with
+    this name."* - which reads like the user's own fault and is not.
+
+    ``atexit`` runs while the interpreter is still whole, so the disconnect packet goes
+    out and the name is free immediately.
+
+    The handler holds a weak reference on purpose. ``atexit`` keeps whatever it is given
+    alive until the process ends, and a strong reference here would keep the connection
+    open for exactly as long as the bug it fixes did.
+
+    :param luanti_ref: Weak reference to the object to disconnect.
+    :return: The handler to hand to :func:`atexit.register`.
+    """
+    def _disconnect_at_exit() -> None:
+        luanti = luanti_ref()
+        if luanti is not None:
+            luanti.disconnect()
+
+    return _disconnect_at_exit
 
 
 @dataclass
@@ -158,7 +215,10 @@ class Luanti:
         :param port: The apisocket port, defaults to 30000
         :param invisible: If True, makes the Miney player invisible and grants creative privilege to be safe from mobs.
         :param world: Name of the world in the local ``.miney`` environment to connect to.
-            Only needed when several exist. Ignored when an explicit ``server`` is given.
+            Only needed when it cannot be worked out: with one world that one is used,
+            and with several the one whose server is running - so a second world next to
+            the one you work in changes nothing while it is shut down. Naming a ``port``
+            picks the world on that port. Ignored when an explicit ``server`` is given.
         :param autostart: Start the local Luanti server if it is not running, and open a
             Luanti game window connected to it. Ignored when an explicit server is given.
         :raises MineyRunError: If the environment has no matching world, several worlds
@@ -166,7 +226,7 @@ class Luanti:
         """
         env_selection = None
         if server is None:
-            env_selection = _resolve_env_world(world)
+            env_selection = _resolve_env_world(world, port)
 
         if env_selection is not None:
             paths, state = env_selection
@@ -255,6 +315,18 @@ class Luanti:
         )
         self._tool = ToolIterable(self, self._tools_cache)
 
+        # Registered once the connection really exists, so a failed connect leaves
+        # nothing behind to run at exit.
+        self._atexit_disconnect = _make_atexit_disconnect(weakref.ref(self))
+        atexit.register(self._atexit_disconnect)
+
+        # Without this, Miney's own player stays dead for the rest of the session: a
+        # corpse standing in the world that answers every command with the position it
+        # died at. See _get_up_again for why the client's own answer is not enough.
+        self._invisible = invisible
+        self._callbacks.register("player_dies", self._get_up_again,
+                                 {"player_name": self.playername})
+
         # Optionally make player invisible and grant creative privilege
         if invisible:
             try:
@@ -263,6 +335,36 @@ class Luanti:
                 player_obj.creative = True
             except Exception as e:
                 logger.error(f"Failed to set invisible/creative for player '{self.playername}': {e}")
+
+    def _get_up_again(self, event) -> None:
+        """
+        Send Miney's own player back into the world after it died.
+
+        Registered for every session, and never for anybody else's player - yours keeps
+        the death screen it is supposed to get.
+
+        The client does answer that screen by itself, but the answer is usually thrown
+        away: the server only accepts a form it is still expecting, and the mod shows
+        ``miney:code_form`` again for every command answer and every event - including
+        the one that says the player just died. The server then logs *"submitted
+        formspec ('__builtin:death') ... possible exploitation attempt"* and the player
+        stays dead. Asking for the respawn from Lua goes through the channel that is
+        always open anyway.
+
+        Invisibility is put back on afterwards, because a game that gives players a skin
+        gives them a fresh one when they respawn.
+
+        :param event: The :class:`~miney.events.PlayerDiesEvent` that arrived.
+        """
+        try:
+            self.lua.run(
+                f"local player = minetest.get_player_by_name({self.lua.dumps(self.playername)})\n"
+                f"if player then player:respawn() end"
+            )
+            if self._invisible:
+                self.players[self.playername].invisible = True
+        except Exception as error:  # noqa: BLE001 - a dead bot is not worth a traceback
+            logger.error("Could not respawn '%s' after it died: %s", self.playername, error)
 
     def __enter__(self):
         """
@@ -496,6 +598,13 @@ class Luanti:
         called automatically when the object is deleted or when exiting a 'with'
         block.
         """
+        # Nothing left for the interpreter to do at exit. Unregistering the instance's
+        # own handler rather than the shared function keeps other open connections.
+        handler = getattr(self, "_atexit_disconnect", None)
+        if handler is not None:
+            atexit.unregister(handler)
+            self._atexit_disconnect = None
+
         # Best-effort cleanup of registered callbacks before dropping the connection
         if hasattr(self, "_callbacks") and self._callbacks:
             try:

--- a/miney/luanti.py
+++ b/miney/luanti.py
@@ -11,6 +11,7 @@ from .luanticlient import LuantiClient
 from .luanticlient.exceptions import LuantiConnectionError
 from .nodes import Nodes
 from .player import PlayerIterable
+from .storage import Storage
 from .tool import ToolIterable
 from .env import manage
 from .env.paths import EnvPaths, find_env
@@ -242,6 +243,7 @@ class Luanti:
         self._lua: Lua = Lua(self.luanti)
         self._chat: Chat = Chat(self)
         self._nodes: Nodes = Nodes(self)
+        self._storage: Storage = Storage(self)
 
         self._tools_cache = self.lua.run(
             """
@@ -326,6 +328,24 @@ class Luanti:
         :return: :class:`~miney.nodes.Nodes`
         """
         return self._nodes
+
+    @property
+    def storage(self) -> 'Storage':
+        """
+        The world's key-value store, used like a dictionary.
+
+        The one place that survives your script ending, and a server restart with it.
+        See :class:`~miney.storage.Storage` for the whole picture.
+
+        :Example:
+
+            >>> lt.storage["home"] = "10,20,30"
+            >>> lt.storage["home"]
+            '10,20,30'
+
+        :return: :class:`~miney.storage.Storage`
+        """
+        return self._storage
 
     @property
     def callbacks(self) -> 'Callback':

--- a/miney/luanticlient/command_handler.py
+++ b/miney/luanticlient/command_handler.py
@@ -216,11 +216,14 @@ class CommandHandler:
     def _handle_death_screen(self):
         """Handles the death screen formspec."""
         if self.client.state.auto_respawn:
-            logger.info("Auto-respawning after death.")
+            # Off by default, see LuantiClientState.auto_respawn: the server refuses this
+            # answer whenever the mod has shown its own form in between, and says so in
+            # its log. Left here for a client used without the miney mod.
+            logger.info("Answering the death screen; the server may ignore it.")
             fields = {"btn_respawn": "true"}
             self.client.send_formspec_response("__builtin:death", fields)
         else:
-            logger.info("Received death screen, auto-respawn is disabled.")
+            logger.debug("Received the death screen; Miney respawns from Lua.")
 
     def _handle_chat_message(self, data: bytes):
         stream = io.BytesIO(data)

--- a/miney/luanticlient/connection.py
+++ b/miney/luanticlient/connection.py
@@ -6,12 +6,47 @@ import struct
 import threading
 import time
 import logging
+from dataclasses import dataclass
 from typing import Callable
 
 from .protocol import Protocol, OriginalPacketPayload, SplitPacketPayload, ControlPacketData
 from .state import ClientStateHolder
 
 logger = logging.getLogger(__name__)
+
+# Reliable delivery. These are Luanti's own numbers, taken from its connection layer
+# so that both ends agree about what "reliable" means.
+#
+# SEND_WINDOW is how many packets may be unacknowledged at once. It is the engine's
+# START_RELIABLE_WINDOW_SIZE (src/network/mtp/internal.h). It is what paces the sender:
+# a full window blocks until an ACK frees a slot, which on a fast link is no wait at
+# all and on a slow one is exactly as much waiting as the link needs.
+SEND_WINDOW = 64
+
+# How long to wait for an ACK before sending the packet again. The engine's own default
+# (`resend_timeout = 0.5`, internal.h), and its floor for an adaptive value is 0.1.
+RESEND_TIMEOUT = 0.5
+
+# Give up after this many attempts. The engine drops the peer at this point; Miney lets
+# the layer above notice, because "the answer never came" is a better error for a user
+# than a connection that vanished.
+MAX_SEND_TRIES = 5
+
+# How long a full window may block before the send is abandoned.
+SEND_STALL_TIMEOUT = 30.0
+
+# How often the receive loop wakes up. It only needs to be quick while there is
+# something to retransmit; the rest of the time it idles on the socket.
+POLL_WHILE_SENDING = 0.05
+POLL_WHILE_IDLE = 1.0
+
+
+@dataclass
+class _Unacked:
+    """A reliable packet that has been sent and not yet acknowledged."""
+    packet: bytes
+    sent_at: float
+    tries: int
 
 
 class Connection:
@@ -45,6 +80,12 @@ class Connection:
         self.split_seqnum = 0
         self.seqnum_lock = threading.Lock()
         self.split_seqnum_lock = threading.Lock()
+
+        # Reliable packets that are on their way out and not yet acknowledged, by
+        # sequence number. The receiver thread removes entries as ACKs arrive and
+        # wakes anyone waiting for a free window slot.
+        self._unacked: dict[int, _Unacked] = {}
+        self._unacked_cond = threading.Condition()
 
     def establish(self) -> bool:
         """
@@ -91,6 +132,9 @@ class Connection:
 
     def disconnect(self):
         """Disconnects from the server and cleans up resources."""
+        # Before the receiver stops, because it is the thread that collects ACKs. A
+        # last message that is still in flight gets a moment to land.
+        self._wait_for_acks(timeout=0.5)
         self.stop_receiver()
 
         if self.state.connected and self.state.peer_id is not None and self.sock and not self.state.access_denied_reason:
@@ -124,11 +168,29 @@ class Connection:
             logger.debug("Receiver thread started.")
 
     def stop_receiver(self):
-        """Stops the background receiver thread."""
+        """
+        Stops the background receiver thread.
+
+        The join is allowed to fail. A script that never used ``with`` leaves the
+        disconnect to ``Luanti.__del__``, which the interpreter calls while it is
+        already shutting down - and joining a thread at that point raises
+        ``PythonFinalizationError`` (a ``RuntimeError``, since Python 3.13). That
+        exception used to escape through :meth:`disconnect` before it got to send the
+        disconnect packet, so the server kept the session alive until it timed out and
+        the next run of the same script was refused with *"Another client is already
+        connected with this name."* The thread is a daemon and the process is ending
+        anyway, so not waiting for it costs nothing; getting the packet out is what
+        matters.
+        """
         self.running = False
+        with self._unacked_cond:  # let go of anyone waiting for a window slot
+            self._unacked_cond.notify_all()
         if self.receive_thread and self.receive_thread.is_alive():
-            self.receive_thread.join(timeout=1.0)
-            logger.debug("Receiver thread stopped.")
+            try:
+                self.receive_thread.join(timeout=1.0)
+                logger.debug("Receiver thread stopped.")
+            except RuntimeError as e:
+                logger.debug(f"Could not join the receiver thread, continuing anyway: {e}")
 
     def _receive_and_keep_alive_loop(self):
         last_keep_alive_time = time.time()
@@ -148,8 +210,13 @@ class Connection:
                     if self.running:
                         logger.error(f"Error in keep-alive: {e}")
 
+            self._resend_expired()
+
             try:
-                self.sock.settimeout(1.0)
+                # Only wake up often while there is something waiting to be
+                # acknowledged; an idle connection goes back to sitting on the socket.
+                self.sock.settimeout(
+                    POLL_WHILE_SENDING if self._unacked else POLL_WHILE_IDLE)
                 data, addr = self.sock.recvfrom(4096)
                 self.state.packets_received += 1
                 logger.debug(f"Received packet from {addr} with length {len(data)}")
@@ -180,6 +247,9 @@ class Connection:
                         logger.debug(
                             f"Updating peer_id from {self.state.peer_id} to {new_peer_id}")
                         self.state.peer_id = new_peer_id
+
+                elif parsed_packet.type == 'ack':
+                    self._handle_ack(parsed_packet.content.seqnum)
 
                 elif parsed_packet.type == 'direct_command':
                     p = parsed_packet.content
@@ -226,6 +296,120 @@ class Connection:
                 command_id = struct.unpack(">H", data[0:2])[0]
                 self.command_processor(command_id, data[2:])
 
+    def _send_reliable(self, packet: bytes, seqnum: int) -> bool:
+        """
+        Send a reliable packet and keep it until the server acknowledges it.
+
+        This is the whole of Miney's flow control. Luanti acknowledges every reliable
+        packet it accepts, and deliberately does *not* acknowledge one that arrives too
+        far ahead of what it expects - its own comment there reads *"if this was a valid
+        packet it's gonna be retransmitted"*. Miney never retransmitted, so a packet lost
+        to a full socket buffer or to the network was lost for good: the split message it
+        belonged to never completed and the call above waited out its timeout for an
+        answer that could not come. The old code avoided that by sending slowly enough
+        that it rarely happened - 495 bytes every 10 ms, about 45 KB/s.
+
+        With the packet kept and resent, speed stops being dangerous. What limits the
+        rate now is :data:`SEND_WINDOW` packets in flight: a full window waits for an
+        ACK, so a fast link runs at its own speed and a slow one is throttled to a window
+        per round trip, which is what a sender is supposed to do.
+
+        :param packet: The fully built packet, kept verbatim so a resend is identical.
+        :param seqnum: Its sequence number, which is how the ACK will name it.
+        :return: True if it went out, False if the window never cleared or the socket
+            refused it.
+        """
+        with self._unacked_cond:
+            deadline = time.monotonic() + SEND_STALL_TIMEOUT
+            while len(self._unacked) >= SEND_WINDOW:
+                if not self.running:
+                    logger.debug("Receiver stopped while waiting for a window slot.")
+                    return False
+                self._unacked_cond.wait(timeout=0.1)
+                if time.monotonic() > deadline:
+                    logger.error(
+                        f"No acknowledgement for {SEND_WINDOW} packets in "
+                        f"{SEND_STALL_TIMEOUT:.0f}s - giving up on this send.")
+                    return False
+            self._unacked[seqnum] = _Unacked(packet, time.monotonic(), 1)
+
+        try:
+            self.sock.sendto(packet, (self.host, self.port))
+            self.state.packets_sent += 1
+            return True
+        except Exception as e:
+            logger.error(f"Error sending reliable packet {seqnum}: {e}")
+            with self._unacked_cond:
+                self._unacked.pop(seqnum, None)
+                self._unacked_cond.notify_all()
+            return False
+
+    def _handle_ack(self, seqnum: int):
+        """
+        Retire an acknowledged packet and free its window slot.
+
+        :param seqnum: The sequence number the server acknowledged.
+        """
+        with self._unacked_cond:
+            if self._unacked.pop(seqnum, None) is not None:
+                self._unacked_cond.notify_all()
+
+    def _resend_expired(self):
+        """
+        Send again anything that has gone unacknowledged for too long.
+
+        Called from the receive loop, which is the only thread that learns about ACKs.
+        The packets are collected under the lock and sent outside it, so a slow socket
+        cannot hold up the ACKs that would empty the queue.
+        """
+        if not self._unacked:
+            return
+
+        now = time.monotonic()
+        due: list[bytes] = []
+        with self._unacked_cond:
+            for seqnum, pending in list(self._unacked.items()):
+                if now - pending.sent_at < RESEND_TIMEOUT:
+                    continue
+                if pending.tries >= MAX_SEND_TRIES:
+                    logger.error(
+                        f"Packet {seqnum} was not acknowledged after "
+                        f"{MAX_SEND_TRIES} attempts - dropping it.")
+                    del self._unacked[seqnum]
+                    continue
+                pending.tries += 1
+                pending.sent_at = now
+                due.append(pending.packet)
+                logger.debug(f"Resending packet {seqnum}, attempt {pending.tries}")
+            self._unacked_cond.notify_all()
+
+        for packet in due:
+            try:
+                self.sock.sendto(packet, (self.host, self.port))
+                self.state.packets_sent += 1
+            except Exception as e:
+                logger.error(f"Error resending a packet: {e}")
+
+    def _wait_for_acks(self, timeout: float):
+        """
+        Wait until everything sent has been acknowledged, or until time runs out.
+
+        Used on the way out, so that a last message is not still sitting in the queue
+        when the socket closes.
+
+        :param timeout: How long to wait, in seconds.
+        """
+        deadline = time.monotonic() + timeout
+        with self._unacked_cond:
+            while self._unacked and self.running:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.debug(
+                        f"{len(self._unacked)} packets still unacknowledged at "
+                        f"disconnect.")
+                    return
+                self._unacked_cond.wait(timeout=remaining)
+
     def _get_next_split_seqnum(self) -> int:
         with self.split_seqnum_lock:
             seqnum = self.split_seqnum
@@ -247,17 +431,14 @@ class Connection:
             offset = i * MAX_CHUNK_SIZE
             chunk_data = data[offset:offset + min(MAX_CHUNK_SIZE, len(data) - offset)]
             with self.seqnum_lock:
+                seqnum = self.state.sequence_number
                 packet = self.protocol.create_reliable_split_packet(
-                    peer_id=self.state.peer_id, sequence_number=self.state.sequence_number,
+                    peer_id=self.state.peer_id, sequence_number=seqnum,
                     split_seqnum=split_seqnum, total_chunks=total_chunks, chunk_num=i,
                     chunk_data=chunk_data)
                 self.state.sequence_number = (self.state.sequence_number + 1) % 65536
-            try:
-                self.sock.sendto(packet, (self.host, self.port))
-                self.state.packets_sent += 1
-                time.sleep(0.01)
-            except Exception as e:
-                logger.error(f"Error sending split chunk {i + 1}/{total_chunks}: {e}")
+            if not self._send_reliable(packet, seqnum):
+                logger.error(f"Error sending split chunk {i + 1}/{total_chunks}")
                 return False
         return True
 
@@ -272,15 +453,10 @@ class Connection:
             return self.send_split_packet(data)
 
         with self.seqnum_lock:
+            seqnum = self.state.sequence_number
             packet = self.protocol.create_reliable_original_packet(
                 peer_id=self.state.peer_id,
-                sequence_number=self.state.sequence_number,
+                sequence_number=seqnum,
                 data=data)
             self.state.sequence_number = (self.state.sequence_number + 1) % 65536
-        try:
-            self.sock.sendto(packet, (self.host, self.port))
-            self.state.packets_sent += 1
-            return True
-        except Exception as e:
-            logger.error(f"Error sending packet: {e}")
-            return False
+        return self._send_reliable(packet, seqnum)

--- a/miney/luanticlient/state.py
+++ b/miney/luanticlient/state.py
@@ -34,7 +34,13 @@ class ClientStateHolder:
         self.last_processed_command_id: int | None = None
 
         # Game world state
-        self.auto_respawn: bool = True
+        # Off, because answering the death screen from here does not work in a session
+        # that uses the miney mod - and every Miney session does. The server accepts an
+        # answer only for the form it still expects, and the mod shows 'miney:code_form'
+        # for every result and every event, so the answer is refused and logged as a
+        # "possible exploitation attempt" in the server's log. Luanti._get_up_again asks
+        # for the respawn over the Lua channel instead.
+        self.auto_respawn: bool = False
         self._player_position: dict[str, float] = {"x": 0.0, "y": 0.0, "z": 0.0}
         self._time_of_day: float = 0.0
         self._time_speed: float = 0.0

--- a/miney/nodes.py
+++ b/miney/nodes.py
@@ -1,8 +1,210 @@
+from math import floor
+from collections.abc import Iterable, Mapping
+from .exceptions import DataError
 from .node import Node
 from .point import Point
-from typing import Union, Iterable, Any, TYPE_CHECKING
+from typing import Union, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .luanti import Luanti
+
+
+def _load_areas(positions: Iterable[tuple[int, int, int]]) -> str:
+    """
+    Build the Lua that makes sure the map is loaded where nodes are about to be set.
+
+    ``minetest.set_node`` does nothing at all in a part of the world the server does
+    not currently have in memory. It does not load it, it does not complain, and it
+    does not raise - it writes a line into the server log and drops the node. Building
+    anything away from a player therefore produced no blocks and no error.
+
+    The engine loads whole 16x16x16 mapblocks, so this asks for each *distinct*
+    mapblock exactly once rather than once per node. That keeps the extra Lua to a few
+    dozen lines for a normal build, and keeps it bounded for nodes scattered across the
+    world - where loading one box around all of them could mean loading half a
+    continent.
+
+    :param positions: The ``(x, y, z)`` of every node about to be written.
+    :return: Lua source, one ``load_area`` per mapblock, or ``""`` if there is nothing
+        to load.
+    """
+    seen: set[tuple[int, int, int]] = set()
+    lines = []
+    for x, y, z in positions:
+        # Shifting floors towards negative infinity, which is the same way mapblock
+        # boundaries run. Integer division would round towards zero and put everything
+        # just below y=0 in the wrong block.
+        block = (floor(x) >> 4, floor(y) >> 4, floor(z) >> 4)
+        if block in seen:
+            continue
+        seen.add(block)
+        lines.append(
+            f"minetest.load_area({{x={block[0] * 16}, "
+            f"y={block[1] * 16}, z={block[2] * 16}}})"
+        )
+    return "\n".join(lines)
+
+
+#: Most blocks written by one call to the server. A ``VoxelManip`` holds the whole box
+#: in memory as a Lua array while it works, so a big enough box would be a memory
+#: problem on the server rather than on the wire. :meth:`Nodes.fill` splits anything
+#: larger into slabs instead of refusing it, so this number never reaches the user.
+_MAX_FILL_VOLUME = 4_000_000
+
+_FILL_LUA = """
+local p1 = {{x = {x1}, y = {y1}, z = {z1}}}
+local p2 = {{x = {x2}, y = {y2}, z = {z2}}}
+local vm = VoxelManip()
+local emin, emax = vm:read_from_map(p1, p2)
+local area = VoxelArea:new{{MinEdge = emin, MaxEdge = emax}}
+local data = vm:get_data()
+local cid = minetest.get_content_id({name})
+local n = 0
+for z = p1.z, p2.z do
+    for y = p1.y, p2.y do
+        local vi = area:index(p1.x, y, z)
+        for _ = p1.x, p2.x do
+            data[vi] = cid
+            vi = vi + 1
+            n = n + 1
+        end
+    end
+end
+vm:set_data(data)
+vm:write_to_map(true)
+return n
+"""
+
+
+#: Reads a cuboid and packs the answer instead of describing every node separately.
+#:
+#: The obvious version builds one Lua table per node with five keys in it and lets the
+#: bridge turn that into JSON. Measured over 32,768 nodes of real terrain that took
+#: 848 ms, and about two thirds of it was the packing rather than the reading - swapping
+#: ``minetest.get_node`` for a VoxelManip changes nothing measurable, because the engine
+#: was never the slow part.
+#:
+#: So the reader stays and the answer changes. Names are sent once and referred to by
+#: number afterwards, and a stretch of identical neighbours collapses into one token, in
+#: the order the nodes are walked. Terrain is mostly stone next to stone and air next to
+#: air, so this is where the size goes: 510 KB becomes 55 KB, and 848 ms becomes 11 ms.
+_GET_LUA = """
+local p1, p2 = {pos1}, {pos2}
+local x1, x2 = math.min(p1.x, p2.x), math.max(p1.x, p2.x)
+local y1, y2 = math.min(p1.y, p2.y), math.max(p1.y, p2.y)
+local z1, z2 = math.min(p1.z, p2.z), math.max(p1.z, p2.z)
+minetest.load_area({{x=x1, y=y1, z=z1}}, {{x=x2, y=y2, z=z2}})
+
+local get_node = minetest.get_node
+local seen, palette, runs = {{}}, {{}}, {{}}
+local last, run = nil, 0
+
+for x = x1, x2 do
+  for y = y1, y2 do
+    for z = z1, z2 do
+      local node = get_node({{x = x, y = y, z = z}})
+      local id = seen[node.name]
+      if not id then
+        palette[#palette + 1] = node.name
+        id = #palette
+        seen[node.name] = id
+      end
+      local token = id .. "," .. node.param1 .. "," .. node.param2
+      if token == last then
+        run = run + 1
+      else
+        if last then runs[#runs + 1] = last .. "x" .. run end
+        last, run = token, 1
+      end
+    end
+  end
+end
+if last then runs[#runs + 1] = last .. "x" .. run end
+
+return table.concat(palette, " ") .. "|" .. table.concat(runs, " ")
+"""
+
+
+def _decode_nodes(packed: str, corner1: tuple[int, int, int],
+                  corner2: tuple[int, int, int], luanti: 'Luanti') -> list[Node]:
+    """
+    Turn the packed answer from :data:`_GET_LUA` back into :class:`~miney.node.Node`.
+
+    The coordinates are not transmitted - they are walked in the same order the server
+    walked them, x outermost and z innermost, which is the order
+    :meth:`Nodes.get` has always returned.
+
+    :param packed: ``"name name name|index,param1,param2xcount ..."``.
+    :param corner1: The lower corner of the region that was asked for.
+    :param corner2: The upper corner.
+    :param luanti: Bound into every node, so ``node.inventory`` works.
+    :return: One Node per position, in the documented order.
+    :raises DataError: If the answer does not describe exactly this region.
+    """
+    x1, y1, z1 = corner1
+    x2, y2, z2 = corner2
+    expected = (x2 - x1 + 1) * (y2 - y1 + 1) * (z2 - z1 + 1)
+
+    names_part, separator, runs_part = packed.partition("|")
+    if not separator:
+        raise DataError(
+            "The server's answer for this region is not in the expected form.")
+    names = names_part.split(" ") if names_part else []
+
+    nodes: list[Node] = []
+    x, y, z = x1, y1, z1
+    try:
+        for token in runs_part.split(" "):
+            if not token:
+                continue
+            head, _, count = token.rpartition("x")
+            index, param1, param2 = head.split(",")
+            name = names[int(index) - 1]
+            param1, param2 = int(param1), int(param2)
+
+            for _ in range(int(count)):
+                nodes.append(Node(x, y, z, name, param1, param2, luanti=luanti))
+                z += 1
+                if z > z2:
+                    z = z1
+                    y += 1
+                    if y > y2:
+                        y = y1
+                        x += 1
+    except (ValueError, IndexError) as e:
+        raise DataError(f"Could not read the server's answer for this region: {e}")
+
+    if len(nodes) != expected:
+        raise DataError(
+            f"The server described {len(nodes)} nodes for a region of {expected}.")
+    return nodes
+
+
+def _slabs(p1: tuple[int, int, int], p2: tuple[int, int, int]):
+    """
+    Cut a box into pieces small enough for one ``VoxelManip`` each.
+
+    Slicing along z first keeps each piece a contiguous run of the wide axes, which is
+    what the fill loop walks anyway. A box so wide that a single z-layer is still too
+    large gets sliced along y as well - that needs an x times y of four million, which
+    no real build has, but a loop that only *usually* terminates is not worth writing.
+
+    :param p1: The lower corner, already sorted and integral.
+    :param p2: The upper corner.
+    :return: Yields ``(corner, corner)`` pairs covering the box exactly once.
+    """
+    dx = p2[0] - p1[0] + 1
+    dy = p2[1] - p1[1] + 1
+
+    z_step = max(1, _MAX_FILL_VOLUME // max(1, dx * dy))
+    y_step = max(1, _MAX_FILL_VOLUME // max(1, dx))
+
+    for z in range(p1[2], p2[2] + 1, z_step):
+        z_end = min(z + z_step - 1, p2[2])
+        if dx * dy <= _MAX_FILL_VOLUME:
+            yield (p1[0], p1[1], z), (p2[0], p2[1], z_end)
+            continue
+        for y in range(p1[1], p2[1] + 1, y_step):
+            yield (p1[0], y, z), (p2[0], min(y + y_step - 1, p2[1]), z_end)
 
 
 class Nodes:
@@ -66,13 +268,14 @@ class Nodes:
         """
         return self._types
 
-    def set(self, node: Union[Node, list]) -> None:
+    def set(self, node: Union[Node, Iterable[Node]]) -> None:
         """
         Set a single or multiple nodes at a given position.
 
         You can get a list of all available node names with :attr:`~miney.Nodes.names`.
 
-        **The `node` parameter can be a single Node object or a list of Node objects for bulk setting.**
+        **The `node` parameter can be a single Node object, or any collection of Node
+        objects - a list, a tuple, a set or a generator - for bulk setting.**
 
         :Examples:
 
@@ -94,27 +297,137 @@ class Nodes:
             ... ]
             >>> lt.nodes.set(nodes_to_set)
 
-        :param node: A single :class:`~miney.node.Node` object or a list of :class:`~miney.node.Node` objects.
+        :param node: A single :class:`~miney.node.Node` object, or a collection of
+            :class:`~miney.node.Node` objects.
+        :raises TypeError: If something other than a Node or a collection of Nodes is
+            passed.
         """
-        # Set a single node
-        if type(node) is Node:
-            self.lt.lua.run(
-                f"minetest.set_node({ self.lt.lua.dumps({'x': node.x, 'y': node.y, 'z': node.z}) }, "
-                f"{self.lt.lua.dumps({'name': node.name})})"
+        # A Node is itself iterable (it is a Point), so it has to be recognised first.
+        if isinstance(node, Node):
+            nodes = [node]
+        # A str and a dict are iterable too, and neither is a collection of nodes.
+        elif isinstance(node, Iterable) and not isinstance(node, (str, bytes, Mapping)):
+            nodes = list(node)  # so a generator survives being walked twice below
+        else:
+            raise TypeError(
+                f"'node' must be a Node or a collection of Nodes, got "
+                f"{type(node).__name__}. A node name alone is not enough - it needs a "
+                f"position: lt.nodes.set(Node(10, 20, 30, name='default:dirt'))"
             )
 
-        # Set many nodes
-        elif type(node) is list:
+        for n in nodes:
+            if not isinstance(n, Node):
+                raise TypeError(
+                    f"Every element must be a Node, got {type(n).__name__}. A Point "
+                    f"carries no node name: Node(point.x, point.y, point.z, "
+                    f"name='default:dirt')"
+                )
 
-            lua = ""
-            # Loop over node, modify name/type, position/offset and generate lua code
-            for n in node:
-                lua += (f"minetest.set_node("
-                        f"{self.lt.lua.dumps({'x': n.x, 'y': n.y, 'z': n.z})}, "
-                        f"{self.lt.lua.dumps({'name': n.name})})\n")
-            self.lt.lua.run(lua)
+        if not nodes:  # nothing to do, and an empty run() would still cost a round trip
+            return
 
-    def get(self, point: Union[Point, Node, Iterable]) -> Node | list[Any] | None:
+        lua = _load_areas([(n.x, n.y, n.z) for n in nodes]) + "\n"
+        # Loop over node, modify name/type, position/offset and generate lua code
+        for n in nodes:
+            lua += (f"minetest.set_node("
+                    f"{self.lt.lua.dumps({'x': n.x, 'y': n.y, 'z': n.z})}, "
+                    f"{self.lt.lua.dumps({'name': n.name})})\n")
+        self.lt.lua.run(lua)
+
+    def fill(self, start: Point, end: Point, name: str) -> int:
+        """
+        Fill a box with one kind of block, at any size.
+
+        This is the fast way to build. :meth:`set` sends one line of Lua per block, so
+        a wall costs as much network as it has blocks in it. ``fill`` sends the two
+        corners and a name - about eighty bytes - and the server does the writing with
+        ``VoxelManip``, its bulk map interface. **Nothing about the size of the box
+        travels**, so a 128x128x64 region costs exactly as much bandwidth as one block.
+
+        Measured against a local server: :meth:`set` writes about 700 blocks a second,
+        ``fill`` about 4,700,000. Levelling a 193x193x76 site takes 0.4 seconds.
+
+        .. important::
+
+            ``fill`` writes blocks and nothing else. The engine's bulk interface skips
+            the machinery that makes blocks *behave*:
+
+            - **No block callbacks.** A chest placed this way has no inventory at all,
+              because the code that gives it one never runs. The same goes for
+              furnaces, signs, doors, beds - anything with a working part.
+            - **Nothing falls.** Sand and gravel with no support stay in the air until
+              something disturbs them.
+            - **Old contents stay behind.** Filling over a chest with air removes the
+              chest but leaves what was inside it in the map, and a chest built at the
+              same spot later inherits it.
+            - **Liquids do not flow.** Water placed this way sits still.
+
+            None of that matters for the thing ``fill`` is for - floors, walls, towers,
+            clearing ground, terrain. For blocks that need to work, use :meth:`set`,
+            which goes through the ordinary placement path.
+
+        :Examples:
+
+            A 64x64 obsidian floor at y=10:
+
+            >>> from miney import Point
+            >>> lt.nodes.fill(Point(0, 10, 0), Point(63, 10, 63), "mcl_core:obsidian")
+            4096
+
+            Clear the air above it - 262,144 blocks, one call, no faster or slower
+            than the floor was:
+
+            >>> lt.nodes.fill(Point(0, 11, 0), Point(63, 74, 63), "air")
+            262144
+
+            A pillar next to the first player:
+
+            >>> here = lt.players[0].position
+            >>> lt.nodes.fill(here + Point(2, 0, 0), here + Point(2, 20, 0),
+            ...               lt.nodes.names.mcl_core.glass)
+            21
+
+        :param start: One corner of the box.
+        :param end: The opposite corner. The two may be given in any order.
+        :param name: What to fill with, e.g. ``"mcl_core:obsidian"`` or ``"air"``.
+            Use :attr:`~miney.Nodes.names` to find one with autocomplete.
+        :return: How many blocks were written.
+        :raises TypeError: If the corners are not points, or the name is not a string.
+        :raises ValueError: If this server has no block of that name.
+        """
+        for label, corner in (("start", start), ("end", end)):
+            if not isinstance(corner, Point):
+                raise TypeError(
+                    f"'{label}' must be a Point, got {type(corner).__name__}. "
+                    f"lt.nodes.fill(Point(0, 10, 0), Point(63, 10, 63), 'air')"
+                )
+        if not isinstance(name, str):
+            raise TypeError(f"'name' must be str, got {type(name).__name__}.")
+        if name not in self._names_cache:
+            raise ValueError(
+                f"This server has no block called {name!r}. Find one with "
+                f"lt.nodes.names - it autocompletes, so lt.nodes.names.mcl_core.stone "
+                f"finds 'mcl_core:stone' in a few keystrokes."
+            )
+
+        p1 = (min(floor(start.x), floor(end.x)), min(floor(start.y), floor(end.y)),
+              min(floor(start.z), floor(end.z)))
+        p2 = (max(floor(start.x), floor(end.x)), max(floor(start.y), floor(end.y)),
+              max(floor(start.z), floor(end.z)))
+
+        written = 0
+        for box in _slabs(p1, p2):
+            written += self.lt.lua.run(
+                _FILL_LUA.format(
+                    x1=box[0][0], y1=box[0][1], z1=box[0][2],
+                    x2=box[1][0], y2=box[1][1], z2=box[1][2],
+                    name=self.lt.lua.dumps(name),
+                ),
+                timeout=120,
+            ) or 0
+        return written
+
+    def get(self, point: Union[Point, Node, Iterable]) -> Node | list[Any]:
         """
         Get the node at the given position. It returns a node object.
         This contains the "x", "y", "z", "param1", "param2" and "name" attributes, where "name" is the node type like
@@ -123,10 +436,24 @@ class Nodes:
         If instead of a single point/node a list or tuple with 2 points/nodes is given, this function returns a list of
         nodes. This list contains a cuboid of nodes with the diagonal between the given points.
 
+        The nodes come back in a fixed order - x changes slowest, then y, and z fastest -
+        so the node at an offset inside the box is at a position you can work out:
+        ``index = dx * ny * nz + dy * nz + dz``. Iterating the list is usually easier.
+
+        A whole region travels as one answer, and identical neighbours are sent once
+        rather than each in turn, which is what terrain mostly consists of. Reading
+        32,768 nodes takes about 30 milliseconds. Most of that is now building the
+        :class:`~miney.node.Node` objects on this side, so ask for the region you want
+        rather than the region you might want.
+
         Tip: You can get a list of all available node names with :attr:`~miney.Nodes.names`.
 
-        :param point: A Point object
-        :return: The node type on this position
+        :param point: A Point object, or a list/tuple of exactly two of them for a cuboid
+        :return: The node on this position, or the list of nodes in the cuboid
+        :raises TypeError: If something other than a Point or a pair of Points is passed
+        :raises ValueError: If the pair does not have exactly two entries
+        :raises miney.exceptions.DataError: If the server's answer does not describe the
+            region that was asked for
         """
         if isinstance(point, Point):  # for a single node
             pos_dict = {'x': point.x, 'y': point.y, 'z': point.z}
@@ -134,36 +461,30 @@ class Nodes:
                 f"return minetest.get_node({self.lt.lua.dumps(pos_dict)})")
             node = Node(point.x, point.y, point.z, **node_data, luanti=self.lt)
             return node
-        elif isinstance(point, (list, tuple)) and len(point) == 2:  # Multiple nodes
+        elif isinstance(point, (list, tuple)):  # Multiple nodes
+            if len(point) != 2:
+                raise ValueError(
+                    f"A cuboid is described by exactly two opposite corners, got "
+                    f"{len(point)}. Pass one Point for a single node, or two for the "
+                    f"box between them."
+                )
             pos1_dict = {'x': point[0].x, 'y': point[0].y, 'z': point[0].z}
             pos2_dict = {'x': point[1].x, 'y': point[1].y, 'z': point[1].z}
-            lnodes = self.lt.lua.run(  # We sort them by the smallest coordinates and get them node per node
-                f"""
-                pos1 = {self.lt.lua.dumps(pos1_dict)}
-                pos2 = {self.lt.lua.dumps(pos2_dict)}
-                minetest.load_area(pos1, pos2)
-                nodes = {{}}
-                if pos1.x <= pos2.x then start_x = pos1.x end_x = pos2.x else start_x = pos2.x end_x = pos1.x end
-                if pos1.y <= pos2.y then start_y = pos1.y end_y = pos2.y else start_y = pos2.y end_y = pos1.y end
-                if pos1.z <= pos2.z then start_z = pos1.z end_z = pos2.z else start_z = pos2.z end_z = pos1.z end
-                for x = start_x, end_x do
-                  for y = start_y, end_y do
-                    for z = start_z, end_z do
-                      node = minetest.get_node({{x = x, y = y, z = z}})
-                      node["x"] = x
-                      node["y"] = y
-                      node["z"] = z
-                      nodes[#nodes+1] = node  -- append node
-                    end
-                  end
-                end
-                return nodes""", timeout=60)
-            nodes = []
-            for n in lnodes:
-                nodes.append(Node(n["x"], n["y"], n["z"], n["name"], n["param1"], n["param2"], luanti=self.lt))
-
-            return nodes
-        return None
+            packed = self.lt.lua.run(
+                _GET_LUA.format(pos1=self.lt.lua.dumps(pos1_dict),
+                                pos2=self.lt.lua.dumps(pos2_dict)),
+                timeout=60)
+            corner1 = (min(floor(point[0].x), floor(point[1].x)),
+                       min(floor(point[0].y), floor(point[1].y)),
+                       min(floor(point[0].z), floor(point[1].z)))
+            corner2 = (max(floor(point[0].x), floor(point[1].x)),
+                       max(floor(point[0].y), floor(point[1].y)),
+                       max(floor(point[0].z), floor(point[1].z)))
+            return _decode_nodes(packed, corner1, corner2, self.lt)
+        raise TypeError(
+            f"'point' must be a Point or Node, or a list of two of them for a cuboid, "
+            f"got {type(point).__name__}."
+        )
 
     def __repr__(self):
         return '<Luanti node functions>'

--- a/miney/player.py
+++ b/miney/player.py
@@ -1,3 +1,4 @@
+import time
 from typing import Union, Iterable, List, TYPE_CHECKING, Optional
 from .exceptions import PlayerNotFoundError, PlayerOffline, LuaError
 from .point import Point
@@ -100,7 +101,7 @@ class Player:
             self.last_login = data["last_login"]
             self.privileges = data["privileges"]
         else:
-            raise PlayerNotFoundError("There is no player with that name")
+            raise PlayerNotFoundError(f"There is no player {self.name!r} on this server.")
 
         self.inventory: Inventory = Inventory(luanti, self)
         """Manipulate player's inventory.
@@ -173,6 +174,7 @@ class Player:
         smooth: bool = False,
         duration: float = 1.0,
         step_interval: float = 0.05,
+        wait: bool = False,
     ):
         """
         Moves the player and/or changes their look direction, with an option for smooth animation.
@@ -218,6 +220,20 @@ class Player:
                 duration=5
             )
 
+            # 7. Fly there and only carry on once the player has arrived
+            player.move(destination=Point(100, 25, 100), smooth=True, duration=5, wait=True)
+            lt.chat.send_to_all("Made it!")
+
+        .. note::
+
+            A smooth move returns straight away, so the script keeps running while the
+            player is still travelling. That is usually what you want - it is how a
+            camera flies over a building site while the building goes on. Use
+            ``wait=True`` when the next line depends on the player having arrived.
+
+            **A second smooth move on the same player replaces the first.** Two of them
+            at once used to drag the player between two paths and arrive at neither.
+
         :param destination: The target position as a :class:`~miney.point.Point`.
         :param distance: The distance to move forward (alternative to `destination`).
         :param look_at: A :class:`~miney.point.Point` to look at (alternative to `yaw`/`pitch`).
@@ -233,7 +249,13 @@ class Player:
         :param smooth: If ``True``, the action is animated over `duration`. If ``False``, it's instant.
         :param duration: The total time for the animation in seconds (if `smooth=True`).
         :param step_interval: The time between each animation step (if `smooth=True`).
-        :raises ValueError: If conflicting or no parameters are provided.
+        :param wait: If ``True``, block until the animation has finished. Needs
+                     ``smooth=True``. Waiting is not the same as
+                     ``time.sleep(duration)``: a step is scheduled for the *next* server
+                     frame, never sooner, so an animation always takes at least its
+                     duration and under load a little longer.
+        :raises ValueError: If conflicting or no parameters are provided, or if ``wait``
+                            is used without ``smooth``.
         """
         if all(p is None for p in [destination, distance, look_at, yaw, pitch]):
             raise ValueError("At least one action (destination, distance, look_at, yaw, pitch) must be provided.")
@@ -241,6 +263,11 @@ class Player:
             raise ValueError("Provide either 'destination' or 'distance', but not both.")
         if look_at is not None and (yaw is not None or pitch is not None):
             raise ValueError("Provide either 'look_at' or 'yaw'/'pitch', but not both.")
+        if wait and not smooth:
+            raise ValueError(
+                "'wait' needs 'smooth=True'. Without an animation there is nothing to "
+                "wait for - the player is already there when move() returns."
+            )
 
         params = {}
         if destination:
@@ -265,6 +292,8 @@ class Player:
             end
             """
             self.lt.lua.run(lua_code)
+            if wait:
+                self._wait_for_animation()
         else:
             # Instantaneous action
             lua_parts = []
@@ -278,8 +307,27 @@ class Player:
                 lua_parts.append(f"player:set_pos({self.lt.lua.dumps(target_pos)})")
 
             if "look_at" in params:
-                direction = params['look_at'] - self.position
-                lua_parts.append(f"player:set_look_dir({self.lt.lua.dumps(direction)})")
+                # Luanti has no set_look_dir - only set_look_horizontal and
+                # set_look_vertical - so the direction has to become two angles first.
+                # vector.dir_to_rotation returns them as {x = pitch, y = yaw}, which is
+                # exactly what smooth_move() in the mod already does for the animated
+                # path; doing the same here keeps instant and smooth in agreement.
+                #
+                # The direction is measured from where the player ends up rather than
+                # from where they started, so "teleport there and look at this" points
+                # at the thing instead of past it.
+                # The pitch is negated. The two halves of this disagree about which way
+                # is up: vector.dir_to_rotation returns asin(direction.y), positive when
+                # the direction points upwards, while set_look_vertical documents
+                # "positive is downwards". Feeding one straight into the other aims the
+                # camera at the mirror image of the target - correct compass bearing,
+                # inverted tilt - which is a 90 degree error when looking 45 degrees up.
+                lua_parts.append(
+                    f"local rot = vector.dir_to_rotation(vector.direction("
+                    f"player:get_pos(), {self.lt.lua.dumps(params['look_at'])})) "
+                    f"player:set_look_horizontal(rot.y) "
+                    f"player:set_look_vertical(-rot.x)"
+                )
             else:
                 if "yaw" in params:
                     lua_parts.append(f"player:set_look_horizontal({params['yaw']})")
@@ -288,6 +336,25 @@ class Player:
 
             if lua_parts:
                 self.lt.lua.run(f"local player = minetest.get_player_by_name('{self.name}'); if player then {' '.join(lua_parts)} end")
+
+    #: How often :meth:`move` with ``wait=True`` asks whether the animation is over. The
+    #: animation itself advances every ``step_interval``, so asking faster than that
+    #: would spend round trips on an answer that cannot have changed.
+    _WAIT_POLL_INTERVAL = 0.05
+
+    def _wait_for_animation(self) -> None:
+        """
+        Block until this player's smooth animation has finished.
+
+        Asked, not pushed. The alternative is for the mod to send a message when the
+        last frame runs, and that message would arrive on the callback channel, which
+        one thread dispatches. Waiting inside a chat command handler would then wait for
+        something that cannot be delivered until the handler returns - a deadlock a
+        beginner has no way to see coming. Polling blocks only the caller.
+        """
+        key = self.lt.lua.dumps(f"move:{self.name}")
+        while self.lt.lua.run(f"return miney_task_busy({key})"):
+            time.sleep(self._WAIT_POLL_INTERVAL)
 
     @property
     def speed(self) -> int:
@@ -384,8 +451,25 @@ class Player:
     def look_dir(self, value: Vector):
         """
         Sets the player's look direction using a vector.
+
+        Luanti has no ``set_look_dir`` to mirror its ``get_look_dir`` - a player is
+        aimed with two angles, not with a vector - so the vector is converted to a yaw
+        and a pitch here. Calling the method that does not exist is what this used to
+        do, and it raised *attempt to call method 'set_look_dir' (a nil value)* for
+        every value.
         """
-        self.lt.lua.run(f"minetest.get_player_by_name('{self.name}'):set_look_dir({self.lt.lua.dumps(value)})")
+        self.lt.lua.run(
+            f"""
+            local player = minetest.get_player_by_name({self.lt.lua.dumps(self.name)})
+            if not player then return false end
+            local rot = vector.dir_to_rotation({self.lt.lua.dumps(value)})
+            player:set_look_horizontal(rot.y)
+            -- Negated: dir_to_rotation counts pitch positive upwards,
+            -- set_look_vertical counts it positive downwards.
+            player:set_look_vertical(-rot.x)
+            return true
+            """
+        )
 
     @property
     def look_vertical(self):
@@ -570,8 +654,21 @@ class Player:
         """
         Get or set the player's visibility.
 
-        When set to ``True``, the player model, nametag, and minimap marker
-        are hidden. When ``False``, restores normal appearance.
+        When set to ``True``, the player model, nametag and minimap marker are hidden,
+        and nothing can point at them any more - no hitbox, no selection box. Miney's own
+        player is invisible from the moment it connects, unless you say
+        ``miney.Luanti(invisible=False)``.
+
+        Setting it back to ``False`` puts back what the player looked like before,
+        including the skin this game gave them. That is remembered in the player's
+        metadata rather than guessed, so it survives a script that ends while its player
+        is hidden.
+
+        .. code-block:: python
+
+            bot = lt.players[lt.playername]
+            bot.invisible = False       # now it can be seen, and hit
+            bot.invisible = True        # out of the way again
 
         .. note::
             This feature may not work for mobs in some games, so they may still attack the player. Maybe it's better to
@@ -597,11 +694,35 @@ class Player:
             raise TypeError("Value for invisible must be a boolean (True or False).")
 
         if value:
-            # Make player invisible
+            # What the player looked like is written down before it is taken away, so
+            # that turning this off puts back what this game gave them - a skin, a model,
+            # a size - instead of a guess. It goes into the player's own metadata, which
+            # survives a disconnect: a script that dies while its player is invisible
+            # leaves a way back rather than a permanently blank character.
             self.lt.lua.run(
                 f"""
                 local player = minetest.get_player_by_name('{self.name}')
                 if not player then return end
+
+                -- minetest.serialize and not write_json: a player's selectionbox is a
+                -- list of numbers *and* a 'rotate' flag in one table, and write_json
+                -- refuses to mix the two - it answers nil, and the appearance would be
+                -- lost with nothing said about it.
+                local meta = player:get_meta()
+                if meta:get_string("miney:before_invisible") == "" then
+                    local props = player:get_properties()
+                    meta:set_string("miney:before_invisible", minetest.serialize({{
+                        visual = props.visual,
+                        mesh = props.mesh,
+                        textures = props.textures,
+                        visual_size = props.visual_size,
+                        pointable = props.pointable,
+                        makes_footstep_sound = props.makes_footstep_sound,
+                        collisionbox = props.collisionbox,
+                        selectionbox = props.selectionbox,
+                        show_on_minimap = props.show_on_minimap
+                    }}) or "")
+                end
 
                 player:set_properties({{
                     visual = "cube",
@@ -620,21 +741,41 @@ class Player:
                 """
             )
         else:
-            # Make player visible
+            # Make player visible again, from what was written down when they were
+            # hidden. The fallback is only for a player this Miney never hid: it is a
+            # plain character, which is right in most games and at least visible in all
+            # of them.
             self.lt.lua.run(
                 f"""
                 local player = minetest.get_player_by_name('{self.name}')
                 if not player then return end
 
-                player:set_properties({{
-                    visual = "mesh",
-                    visual_size = {{x = 1, y = 1}},
-                    pointable = true,
-                    makes_footstep_sound = true,
-                    collisionbox = {{-0.3, -1.0, -0.3, 0.3, 1.0, 0.3}},
-                    selectionbox = {{-0.3, -1.0, -0.3, 0.3, 1.0, 0.3}},
-                    show_on_minimap = true
-                }})
+                local meta = player:get_meta()
+                local saved = meta:get_string("miney:before_invisible")
+                local restored = false
+                if saved ~= "" then
+                    -- deserialize answers nil for anything it cannot read, which is the
+                    -- whole error handling this needs; the sandbox has no pcall.
+                    local props = minetest.deserialize(saved)
+                    if type(props) == "table" then
+                        player:set_properties(props)
+                        restored = true
+                    end
+                    meta:set_string("miney:before_invisible", "")
+                end
+
+                if not restored then
+                    player:set_properties({{
+                        visual = "mesh",
+                        textures = {{"character.png"}},
+                        visual_size = {{x = 1, y = 1}},
+                        pointable = true,
+                        makes_footstep_sound = true,
+                        collisionbox = {{-0.3, -1.0, -0.3, 0.3, 1.0, 0.3}},
+                        selectionbox = {{-0.3, -1.0, -0.3, 0.3, 1.0, 0.3}},
+                        show_on_minimap = true
+                    }})
+                end
 
                 player:set_nametag_attributes({{
                     color = {{a = 255, r = 255, g = 255, b = 255}}
@@ -720,7 +861,9 @@ class PlayerIterable:
         else:
             if type(item_key) == int:
                 return self.__getattribute__(self.__online_players[item_key])
-            raise IndexError("unknown player")
+            online = ", ".join(repr(name) for name in self.__online_players)
+            who = f"Online: {online}." if online else "Nobody is online."
+            raise PlayerNotFoundError(f"There is no player {item_key!r}. {who}")
 
     def __len__(self):
         return len(self.__online_players)

--- a/miney/storage.py
+++ b/miney/storage.py
@@ -1,0 +1,196 @@
+"""
+A place on the server where a script can leave something for the next run.
+"""
+from collections.abc import ItemsView, Iterator, KeysView, MutableMapping, ValuesView
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .luanti import Luanti
+
+
+logger = logging.getLogger(__name__)
+
+
+class Storage(MutableMapping):
+    """
+    The world's key-value store, used like a dictionary.
+
+    Everything a script does is gone when it ends: variables live in Python, and even
+    the Lua names from :meth:`~miney.Lua.run` disappear with the connection. This is
+    the exception. What you put here is written into the world and is still there for
+    the next run, and after a server restart::
+
+        >>> lt.storage["home"] = "10,20,30"
+        >>> lt.storage["home"]
+        '10,20,30'
+
+    It behaves like a ``dict`` - ``in``, ``len()``, ``for``, ``.get()``, ``.pop()``,
+    ``.update()`` and ``del`` all work::
+
+        >>> "home" in lt.storage
+        True
+        >>> for key, value in lt.storage.items():
+        ...     print(key, value)
+        home 10,20,30
+        >>> del lt.storage["home"]
+
+    **Keys and values are strings, both of them.** Luanti writes text and nothing else -
+    its ``set_int`` and ``set_float`` only convert to text on the way in, and what comes
+    back out is a string either way. So Miney does not pretend otherwise: assigning a
+    number raises a :class:`TypeError` instead of silently handing back ``"7"`` where you
+    wrote ``7``. Convert on the way in and out::
+
+        >>> lt.storage["visits"] = str(41 + 1)
+        >>> int(lt.storage["visits"])
+        42
+
+    For anything with a shape, use :mod:`json`::
+
+        >>> import json
+        >>> lt.storage["seen"] = json.dumps({"players": ["Steve", "Alex"]})
+        >>> json.loads(lt.storage["seen"])["players"]
+        ['Steve', 'Alex']
+
+    There is one store per world, not one per player, and it is not private: every
+    Miney script connecting to that world reads and writes the same keys. Prefix what
+    belongs to one project. No other mod on the server sees them though - Luanti files
+    every key under the mod that wrote it, so nothing here can collide with a game's
+    own data.
+
+    You do not create this class yourself, it is reached through
+    :attr:`~miney.Luanti.storage`.
+    """
+
+    def __init__(self, luanti: "Luanti"):
+        """
+        :param luanti: The parent :class:`~miney.Luanti` object.
+        """
+        self.lt = luanti
+
+    def __repr__(self) -> str:
+        fields = self._fields()
+        if len(fields) > 5:
+            return f"<Luanti Storage: {len(fields)} keys>"
+        return f"<Luanti Storage: {fields!r}>"
+
+    def _fields(self) -> dict[str, str]:
+        """
+        The whole store, in one call.
+
+        Read through ``to_table()`` rather than ``get_string()`` on purpose: Luanti
+        still supports a deprecated ``${key}`` syntax, and ``get_string("${home}")``
+        returns the value of *home* instead of the text that was stored. ``to_table()``
+        hands out what was actually written.
+
+        :return: Every key and value. Empty while nothing is stored.
+        """
+        fields = self.lt.lua.run("return storage:to_table().fields")
+        # An empty store serializes as nil, not as an empty table.
+        return fields or {}
+
+    @staticmethod
+    def _check_key(key: str) -> str:
+        """
+        :param key: The key to validate.
+        :return: The key, unchanged.
+        :raises TypeError: If the key is not a string.
+        :raises ValueError: If the key is empty.
+        """
+        if not isinstance(key, str):
+            raise TypeError(
+                f"Storage keys are strings, not {type(key).__name__}. "
+                f'Use lt.storage[str({key!r})] if you meant the text.'
+            )
+        if not key:
+            raise ValueError("Storage keys cannot be empty.")
+        return key
+
+    def __getitem__(self, key: str) -> str:
+        """
+        :param key: The key to look up.
+        :return: The stored text.
+        :raises KeyError: If the key is not in the store.
+        """
+        value = self._fields().get(self._check_key(key))
+        if value is None:
+            raise KeyError(key)
+        return value
+
+    def __setitem__(self, key: str, value: str) -> None:
+        """
+        :param key: The key to store under.
+        :param value: The text to store.
+        :raises TypeError: If the key or the value is not a string.
+        :raises ValueError: If the key or the value is empty.
+        """
+        self._check_key(key)
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Storage values are strings, not {type(value).__name__}. "
+                f"Use str({value!r}) for a single value, or json.dumps({value!r}) "
+                f"for a list or a dictionary."
+            )
+        if not value:
+            raise ValueError(
+                "Storage cannot hold an empty string: Luanti deletes a key when it is "
+                f'set to "". Use "del lt.storage[{key!r}]" if that is what you mean.'
+            )
+        self.lt.lua.run(
+            f"storage:set_string({self.lt.lua.dumps(key)}, {self.lt.lua.dumps(value)}) "
+            f"return true"
+        )
+
+    def __delitem__(self, key: str) -> None:
+        """
+        :param key: The key to remove.
+        :raises KeyError: If the key is not in the store.
+        """
+        self._check_key(key)
+        removed = self.lt.lua.run(
+            f"local key = {self.lt.lua.dumps(key)} "
+            f"if not storage:contains(key) then return false end "
+            f"storage:set_string(key, '') "
+            f"return true"
+        )
+        if not removed:
+            raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        """
+        :return: An iterator over the keys.
+        """
+        return iter(self._fields())
+
+    def __len__(self) -> int:
+        """
+        :return: How many keys are stored.
+        """
+        return len(self._fields())
+
+    def keys(self) -> KeysView[str]:
+        """
+        :return: All keys, read in a single call to the server.
+        """
+        return self._fields().keys()
+
+    def values(self) -> ValuesView[str]:
+        """
+        :return: All values, read in a single call to the server.
+        """
+        return self._fields().values()
+
+    def items(self) -> ItemsView[str, str]:
+        """
+        :return: All key-value pairs, read in a single call to the server.
+        """
+        return self._fields().items()
+
+    def clear(self) -> None:
+        """
+        Remove everything from the store.
+
+        Affects every script using this world, not only yours.
+        """
+        self.lt.lua.run("storage:from_table(nil) return true")
+        logger.info("Cleared the world storage.")

--- a/mod_data/miney/callbacks.lua
+++ b/mod_data/miney/callbacks.lua
@@ -50,19 +50,301 @@ local function valid_chatcommand_name(name)
     return type(name) == "string" and name:match("^[a-z0-9_:+%-]+$") ~= nil
 end
 
--- Supported events that clients can subscribe to
-local SUPPORTED_EVENTS = {
-    chat_message = true,
-    player_leaves = true,
-    player_joins = true,
+-- The name of whoever a callback hands us, as a plain string.
+--
+-- Two things can go missing here and neither is an error: a node dug by a mod has no
+-- digger at all, and ObjectRef:get_player_name() answers "" for anything that is not a
+-- player - a mob punching someone, an arrow. Both arrive as "".
+local function object_name(obj)
+    if obj == nil then
+        return ""
+    end
+    return obj:get_player_name() or ""
+end
+
+-- A position as three plain numbers.
+--
+-- Luanti hands out vectors with a metatable, and write_json would carry whatever else
+-- is attached to them across the wire. Only x, y and z are anybody's business.
+local function point(pos)
+    return {x = pos.x, y = pos.y, z = pos.z}
+end
+
+-- Every event a client can subscribe to.
+--
+-- `on` is the Luanti registrar, `fields` turns its arguments into the payload the Python
+-- side receives, and `keys` names the fields a filter may match on. Adding an event means
+-- adding an entry here: the registration, the filtering and the dispatch below are
+-- written once and do not grow with the list.
+--
+-- The payload keys are spelled the way miney/events.py spells its attributes, so an event
+-- travels from Luanti into a Python attribute without being renamed anywhere on the way.
+local EVENTS = {
+    chat_message = {
+        on = minetest.register_on_chat_message,
+        keys = {"sender_name", "message"},
+        fields = function(name, message)
+            return {sender_name = name, message = message}
+        end,
+    },
+    player_joins = {
+        on = minetest.register_on_joinplayer,
+        keys = {"player_name", "last_login"},
+        fields = function(player, last_login)
+            return {player_name = player:get_player_name(), last_login = last_login}
+        end,
+    },
+    player_leaves = {
+        on = minetest.register_on_leaveplayer,
+        keys = {"player_name", "timed_out"},
+        fields = function(player, timed_out)
+            return {player_name = player:get_player_name(), timed_out = timed_out}
+        end,
+    },
+    node_dug = {
+        on = minetest.register_on_dignode,
+        keys = {"pos", "node_name", "player_name"},
+        fields = function(pos, oldnode, digger)
+            return {pos = point(pos), node_name = oldnode.name,
+                    player_name = object_name(digger)}
+        end,
+    },
+    node_placed = {
+        on = minetest.register_on_placenode,
+        keys = {"pos", "node_name", "player_name"},
+        fields = function(pos, newnode, placer)
+            return {pos = point(pos), node_name = newnode.name,
+                    player_name = object_name(placer)}
+        end,
+    },
+    node_punched = {
+        on = minetest.register_on_punchnode,
+        keys = {"pos", "node_name", "player_name"},
+        fields = function(pos, node, puncher)
+            return {pos = point(pos), node_name = node.name,
+                    player_name = object_name(puncher)}
+        end,
+    },
+    player_dies = {
+        on = minetest.register_on_dieplayer,
+        keys = {"player_name", "reason"},
+        fields = function(player, reason)
+            return {player_name = object_name(player),
+                    reason = (reason and reason.type) or "unknown"}
+        end,
+    },
+    player_respawns = {
+        on = minetest.register_on_respawnplayer,
+        keys = {"player_name"},
+        fields = function(player)
+            return {player_name = object_name(player)}
+        end,
+    },
+    player_punched = {
+        on = minetest.register_on_punchplayer,
+        keys = {"player_name", "hitter_name", "damage"},
+        fields = function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage)
+            return {player_name = object_name(player), hitter_name = object_name(hitter),
+                    damage = damage or 0}
+        end,
+    },
+    player_hp_changed = {
+        -- The second argument is what makes this a *logger* rather than a modifier. A
+        -- modifier has to return the hp change it wants, and that answer would have to
+        -- come back from Python from inside the callback, with the server waiting. A
+        -- logger is only told what happened, which is all this can promise.
+        on = function(handler)
+            minetest.register_on_player_hpchange(handler, false)
+        end,
+        keys = {"player_name", "hp_change", "hp", "reason"},
+        fields = function(player, hp_change, reason)
+            -- The engine applies the change *after* the loggers have run, so get_hp()
+            -- here still answers with the health from before it - reporting that as 'hp'
+            -- would say "20 left" to somebody who just took four damage. So the value is
+            -- worked out, and kept inside the range the game allows: a hit that takes
+            -- more than is left ends at 0, not below.
+            local maximum = (player:get_properties() or {}).hp_max or 20
+            local after = math.max(0, math.min(player:get_hp() + hp_change, maximum))
+            return {
+                player_name = object_name(player),
+                hp_change = hp_change,
+                hp = after,
+                reason = (reason and reason.type) or "unknown",
+            }
+        end,
+    },
 }
 
--- [client_id] = { player = "<name>", subs = { chat_message = true }, cmds = { [name] = true } }
+-- [client_id] = { player = "<name>", subs = { chat_message = { [handler_id] = {filter = {...}} } }, cmds = { [name] = true } }
 local miney_cb = {
     clients = {},
     -- [public_name] = { client_id = "<uuid>", def = { ... } }
     commands = {}
 }
+
+local function event_names()
+    local names = {}
+    for name in pairs(EVENTS) do
+        names[#names + 1] = name
+    end
+    table.sort(names)
+    return table.concat(names, ", ")
+end
+
+local function is_scalar(value)
+    local kind = type(value)
+    return kind == "string" or kind == "number" or kind == "boolean"
+end
+
+-- One value, or a list of values, and every one of them something that can be compared
+-- with '=='.
+--
+-- Anything else is refused rather than accepted and never matched. A position is the
+-- case that makes this necessary: {pos = {x = 1, y = 2, z = 3}} looks like a perfectly
+-- sensible filter, and matches() would read that table as a list of accepted values,
+-- find no numbered entries in it and reject every event for the rest of the session -
+-- in silence, because nothing about "no events ever" says why.
+local function valid_filter_value(want)
+    if is_scalar(want) then
+        return true
+    end
+    if type(want) ~= "table" then
+        return false
+    end
+    local count = 0
+    for _ in pairs(want) do
+        count = count + 1
+    end
+    if count == 0 then
+        return false
+    end
+    for index = 1, count do
+        if not is_scalar(want[index]) then
+            return false
+        end
+    end
+    return true
+end
+
+-- A filter naming a field its event never sends would match nothing and say nothing
+-- about it, so it is refused at subscription time instead of at delivery time.
+local function valid_filter(event_name, filter)
+    if filter == nil then
+        return true
+    end
+    if type(filter) ~= "table" then
+        return nil, "A filter must be a table of field names and values."
+    end
+    local allowed = {}
+    for _, key in ipairs(EVENTS[event_name].keys) do
+        allowed[key] = true
+    end
+    for key, want in pairs(filter) do
+        if not allowed[key] then
+            return nil, ("Event '%s' has no field '%s'. It sends: %s."):format(
+                event_name, tostring(key), table.concat(EVENTS[event_name].keys, ", "))
+        end
+        if not valid_filter_value(want) then
+            return nil, ("Filter '%s' has to be a string, a number, a boolean or a list "
+                .. "of those. A position or any other table cannot be compared this way; "
+                .. "let the event through and decide in your own code."):format(tostring(key))
+        end
+    end
+    return true
+end
+
+-- A filter is a flat table of payload field -> accepted value, or field -> list of
+-- accepted values. Every field has to match; no filter accepts everything.
+--
+-- Deliberately no ranges and no areas. The one event that needs an area filter is
+-- player_moves, which needs a rate limit in the same breath, and both belong to that
+-- event rather than here.
+local function matches(filter, payload)
+    if filter == nil then
+        return true
+    end
+    for key, want in pairs(filter) do
+        local have = payload[key]
+        if type(want) == "table" then
+            local hit = false
+            for _, one in ipairs(want) do
+                if one == have then
+                    hit = true
+                    break
+                end
+            end
+            if not hit then
+                return false
+            end
+        elseif want ~= have then
+            return false
+        end
+    end
+    return true
+end
+
+local function anyone_wants(event_name)
+    for _, rec in pairs(miney_cb.clients) do
+        local subs = rec.subs and rec.subs[event_name]
+        if subs and next(subs) ~= nil then
+            return true
+        end
+    end
+    return false
+end
+
+-- The single way an event leaves this mod.
+--
+-- One connection can watch the same event from several handlers that disagree about what
+-- is interesting, so every handler is its own subscription with its own filter, and the
+-- message names the handlers it is for. That keeps the whole comparison here: the Python
+-- side is told which of its functions this event is meant for and does not have to work
+-- it out a second time from the filters it once sent.
+--
+-- Still one message however many handlers match. Every event costs a formspec, and that
+-- channel carries the results of lua.run as well.
+local function broadcast(event_name, payload)
+    for client_id, rec in pairs(miney_cb.clients) do
+        local subs = rec.subs and rec.subs[event_name]
+        if subs then
+            local handlers = {}
+            for handler_id, sub in pairs(subs) do
+                if matches(sub.filter, payload) then
+                    handlers[#handlers + 1] = handler_id
+                end
+            end
+            if #handlers > 0 then
+                send_callbacks_json(rec.player, {
+                    event = event_name,
+                    payload = payload,
+                    ts = os.time(),
+                    client_id = client_id,
+                    handlers = handlers,
+                })
+            end
+        end
+    end
+end
+
+-- Hook every event into Luanti, once, while the mod loads. Luanti has no unregister for
+-- these - builtin/game/register.lua only ever appends - so registration cannot depend on
+-- anyone being interested yet. anyone_wants() is what makes that free: with nobody
+-- subscribed the handler walks an empty table and returns, and the payload for the event
+-- is never built.
+--
+-- The wrapper returns nothing on purpose. A truthy return from an on_chat_message
+-- handler would swallow the message. An event whose return value the engine actually
+-- reads - register_on_prejoinplayer, the allow_* family - cannot be listed in EVENTS at
+-- all, because the answer would have to come back from Python from inside the callback.
+local function register_events()
+    for name, ev in pairs(EVENTS) do
+        ev.on(function(...)
+            if anyone_wants(name) then
+                broadcast(name, ev.fields(...))
+            end
+        end)
+    end
+end
 
 local function cleanup_player_callbacks(player_name)
     local to_unregister = {}
@@ -141,12 +423,31 @@ local function handle_receive_fields(player, fields)
             send_cb_error(player_name, "Field 'events' must be a list.", client_id, "bad_request")
             return true
         end
+        local handler_id = req.handler
+        if type(handler_id) ~= "string" or handler_id == "" then
+            send_cb_error(player_name, "Missing 'handler' in request.", client_id, "bad_request")
+            return true
+        end
+        -- Everything is checked before anything is stored, so a rejected request leaves
+        -- no half-finished subscription behind.
         for _, ev in ipairs(events) do
-            if SUPPORTED_EVENTS[ev] then
-                rec.subs[ev] = true
+            if not EVENTS[ev] then
+                send_cb_error(player_name, ("Unknown event '%s'. Available: %s."):format(
+                    tostring(ev), event_names()), client_id, "bad_request")
+                return true
+            end
+            local filter_ok, why = valid_filter(ev, req.filter)
+            if not filter_ok then
+                send_cb_error(player_name, why, client_id, "bad_request")
+                return true
             end
         end
-        log("action", ("register: client_id=%s, events_count=%d"):format(client_id, #(req.events or {})))
+        for _, ev in ipairs(events) do
+            rec.subs[ev] = rec.subs[ev] or {}
+            rec.subs[ev][handler_id] = {filter = req.filter}
+        end
+        log("action", ("register: client_id=%s, handler=%s, events_count=%d, filtered=%s"):format(
+            client_id, handler_id, #(req.events or {}), tostring(req.filter ~= nil)))
         send_cb_ack(player_name, action, client_id)
         return true
 
@@ -156,12 +457,23 @@ local function handle_receive_fields(player, fields)
             send_cb_error(player_name, "Field 'events' must be a list.", client_id, "bad_request")
             return true
         end
+        -- Without a handler this drops every subscription for the event, which is what
+        -- a client shutting down sends.
+        local handler_id = req.handler
         for _, ev in ipairs(events) do
-            if SUPPORTED_EVENTS[ev] then
-                rec.subs[ev] = nil
+            if EVENTS[ev] and rec.subs[ev] then
+                if handler_id then
+                    rec.subs[ev][handler_id] = nil
+                    if next(rec.subs[ev]) == nil then
+                        rec.subs[ev] = nil
+                    end
+                else
+                    rec.subs[ev] = nil
+                end
             end
         end
-        log("action", ("unregister: client_id=%s, events_count=%d"):format(client_id, #(req.events or {})))
+        log("action", ("unregister: client_id=%s, handler=%s, events_count=%d"):format(
+            client_id, tostring(handler_id), #(req.events or {})))
         send_cb_ack(player_name, action, client_id)
         return true
 
@@ -190,7 +502,7 @@ local function handle_receive_fields(player, fields)
                 log("action", ("chatcommand invoked: name=%s, issuer=%s, param=%s"):format(name, issuer, param or ""))
                 local event = {
                     event = "chatcommand",
-                    payload = { name = name, issuer = issuer, param = param or "" },
+                    payload = { command_name = name, issuer = issuer, param = param or "" },
                     ts = os.time(),
                     client_id = client_id,
                 }
@@ -229,62 +541,15 @@ local function handle_receive_fields(player, fields)
     end
 end
 
--- Broadcast chat messages to subscribed Miney clients
-minetest.register_on_chat_message(function(name, message)
-    local delivered = 0
-    for client_id, rec in pairs(miney_cb.clients) do
-        if rec.subs and rec.subs.chat_message then
-            local event = {
-                event = "chat_message",
-                payload = { name = name, message = message },
-                ts = os.time(),
-                client_id = client_id,
-            }
-            send_callbacks_json(rec.player, event)
-            delivered = delivered + 1
-        end
-    end
-    log("info", ("on_chat_message: name=%s, delivered=%d"):format(name, delivered))
-    return false
-end)
+register_events()
 
--- Cleanup and event generation on player leave
+-- After register_events(), and that is not cosmetic: Luanti runs leave handlers in
+-- registration order, so the player_leaves event goes out while the leaving client's
+-- subscriptions still exist. Tearing them down first would drop the last event.
 minetest.register_on_leaveplayer(function(player, timed_out)
     local player_name = player:get_player_name()
     log("action", ("on_leaveplayer: player=%s, timed_out=%s"):format(player_name, tostring(timed_out)))
-
-    -- Broadcast 'player_leaves' event to subscribed Miney clients
-    for client_id, rec in pairs(miney_cb.clients) do
-        if rec.subs and rec.subs.player_leaves then
-            local event = {
-                event = "player_leaves",
-                payload = { name = player_name, timed_out = timed_out },
-                ts = os.time(),
-                client_id = client_id,
-            }
-            send_callbacks_json(rec.player, event)
-        end
-    end
-
     cleanup_player_callbacks(player_name)
-end)
-
--- Broadcast an event when a new player joins
-minetest.register_on_joinplayer(function(player, last_login)
-    local player_name = player:get_player_name()
-    log("action", ("on_joinplayer: player=%s, last_login=%s"):format(player_name, tostring(last_login)))
-
-    for client_id, rec in pairs(miney_cb.clients) do
-        if rec.subs and rec.subs.player_joins then
-            local event = {
-                event = "player_joins",
-                payload = { name = player_name, last_login = last_login },
-                ts = os.time(),
-                client_id = client_id,
-            }
-            send_callbacks_json(rec.player, event)
-        end
-    end
 end)
 
 -- Cleanup on shutdown

--- a/mod_data/miney/init.lua
+++ b/mod_data/miney/init.lua
@@ -22,7 +22,11 @@ local form_version = 4
 -- would not survive, and raise REQUIRED_MOD_API in miney/lua.py to match.
 --
 --   1  storage in the sandbox, the instruction budget, no getfenv
-local MOD_API = 1
+--   2  timers belong to the connection that started them, miney_task_busy
+--   3  event payloads name their fields like miney/events.py, event filters are honoured
+--   4  node and player events (node_dug, node_placed, node_punched, player_dies,
+--      player_respawns, player_punched, player_hp_changed), filter values are checked
+local MOD_API = 4
 
 -- Logger function for consistent logging
 local function log(level, message)
@@ -108,6 +112,8 @@ function minetest.send_leave_message(player_name, timed_out)
     return builtin_send_leave_message(player_name, timed_out)
 end
 
+-- Before player.lua: smooth_move registers its frames here.
+dofile(minetest.get_modpath(modname) .. "/tasks.lua")
 dofile(minetest.get_modpath(modname) .. "/player.lua")
 local callbacks = dofile(minetest.get_modpath(modname) .. "/callbacks.lua")
 
@@ -239,6 +245,28 @@ local function scratch_for(player_name)
     local scratch = player_scratch[player_name]
     if not scratch then
         scratch = setmetatable({}, {__index = cached_env})
+
+        -- A timer this connection starts has to be findable again when it leaves, so
+        -- minetest.after is shadowed by one that keeps the handle it hands back.
+        -- Everything else falls through to the real table. Code in the sandbox is
+        -- written exactly as it would be in a mod; it is this side that remembers.
+        scratch.minetest = setmetatable({
+            after = function(delay, fn, ...)
+                return miney_tasks.after(player_name, delay, fn, nil, ...)
+            end,
+        }, {__index = minetest})
+
+        -- Bound to the caller for the same reason: its frames are this connection's.
+        scratch.smooth_move = function(player, params)
+            return smooth_move(player, params, player_name)
+        end
+
+        -- How Player.move(wait=True) asks whether the animation is over. Plumbing, not
+        -- something a script is meant to reach for.
+        scratch.miney_task_busy = function(key)
+            return miney_tasks.busy(player_name, key)
+        end
+
         player_scratch[player_name] = scratch
     end
     return scratch

--- a/mod_data/miney/init.lua
+++ b/mod_data/miney/init.lua
@@ -12,6 +12,18 @@ end)()
 -- Formspec related variables
 local form_version = 4
 
+-- What this mod promises the Python side, sent with every answer so it can check once
+-- and say something useful instead of failing halfway through.
+--
+-- Deliberately not the Miney release number. The Python package is versioned in
+-- miney/__init__.py and that stays the only place to bump at release time; this counts
+-- something slower - the request and response contract between the two halves. Raise it
+-- when a command, a field or a name in the sandbox changes in a way an older Python
+-- would not survive, and raise REQUIRED_MOD_API in miney/lua.py to match.
+--
+--   1  storage in the sandbox, the instruction budget, no getfenv
+local MOD_API = 1
+
 -- Logger function for consistent logging
 local function log(level, message)
     local lvl = LOG_LEVELS[(level or LOG_LEVEL_DEFAULT):lower()] or LOG_LEVELS.info
@@ -59,14 +71,60 @@ local function is_local_address(addr)
     return addr == "::ffff:127.0.0.1" or addr == "127.0.0.1"
 end
 
+-- The Miney client identifies itself by the version string it sends in
+-- TOSERVER_CLIENT_READY. The engine keeps that per connection, so this is the one
+-- way to tell a script's session apart from a person with a real client.
+local function is_miney_client(player_name)
+    local client_info = minetest.get_player_information(player_name) or {}
+    return client_info.version_string == "miney_v1.0"
+end
+
+-- Miney logs in as a real player account, so every script start and stop announced
+-- "*** Miney joined the game." to everyone on the server. That is noise: nobody
+-- arrived, a program connected. The engine has no switch for it, but builtin calls
+-- these two through the global table (builtin/game/misc.lua), so a mod can wrap them.
+--
+-- Join is decided from the live connection; by the time the leave message is sent the
+-- client may already be gone, so remember the name while it is still knowable.
+local miney_client_names = {}
+local builtin_send_join_message = minetest.send_join_message
+local builtin_send_leave_message = minetest.send_leave_message
+
+function minetest.send_join_message(player_name)
+    if is_miney_client(player_name) then
+        miney_client_names[player_name] = true
+        log("action", "Suppressed join message for the Miney client '" .. player_name .. "'.")
+        return
+    end
+    return builtin_send_join_message(player_name)
+end
+
+function minetest.send_leave_message(player_name, timed_out)
+    if miney_client_names[player_name] then
+        miney_client_names[player_name] = nil
+        log("action", "Suppressed leave message for the Miney client '" .. player_name .. "'.")
+        return
+    end
+    return builtin_send_leave_message(player_name, timed_out)
+end
+
 dofile(minetest.get_modpath(modname) .. "/player.lua")
 local callbacks = dofile(minetest.get_modpath(modname) .. "/callbacks.lua")
 
 local cached_env = nil
 
+-- Fetched here because minetest.get_mod_storage() only works while mods load; called
+-- later, from inside the sandbox, it returns nil. This is the one place in Miney where
+-- a script can put something that outlives its connection, and the server restart after
+-- it. It is written to the world directory, so it belongs to the world, not to a player.
+local mod_storage = minetest.get_mod_storage()
+
 -- Register the 'miney' privilege
+-- Worth being blunt in the description: this is not "may use a tool", it is code
+-- execution inside the server process. Grant it the way you grant /lua, not the way
+-- you grant /home.
 minetest.register_privilege("miney", {
-    description = "Allows execution of Lua code via the miney mod",
+    description = "Run Lua code on this server through Miney. Full mod-level access to the world - only grant to people you trust with the server itself.",
     give_to_singleplayer = false
 })
 
@@ -85,7 +143,7 @@ end
 local function show_code_form(player_name, result_table, execution_id)
     local client_info = minetest.get_player_information(player_name) or {}
     local client_ip = client_info.address
-    local is_miney_client = client_info and client_info.version_string == "miney_v1.0"
+    local miney_client = is_miney_client(player_name)
 
     -- Handle unauthorized access first and exit early.
     if not is_local_address(client_ip) and not minetest.check_player_privs(player_name, {miney = true}) then
@@ -105,7 +163,8 @@ local function show_code_form(player_name, result_table, execution_id)
         -- Create the error response payload.
         local error_response = {
             error = "Permission denied: You lack the 'miney' privilege to execute code.",
-            admins = admins_with_privs
+            admins = admins_with_privs,
+            mod_api = MOD_API
         }
         if execution_id then
             error_response.execution_id = execution_id
@@ -117,7 +176,7 @@ local function show_code_form(player_name, result_table, execution_id)
         chat_send_to_priv("privs", admin_notification)
 
         -- Send the appropriate response based on client type.
-        if is_miney_client then
+        if miney_client then
             minetest.show_formspec(player_name, "miney:code_form", minetest.write_json(error_response))
         else
             minetest.chat_send_player(player_name, error_response.error)
@@ -134,9 +193,14 @@ local function show_code_form(player_name, result_table, execution_id)
     end
 
     -- If we reach here, the player is authorized.
-    if is_miney_client then
+    if miney_client then
         --log("action", "Sending JSON response to LuantiClient " .. player_name)
-        
+
+        -- Carried by every answer including the empty warm-up one, so the client knows
+        -- what it is talking to before it sends the first line of code. Only for Miney:
+        -- a person looking at the form has no use for it in their result box.
+        response_data.mod_api = MOD_API
+
         local final_json_response = minetest.write_json(response_data)
         minetest.show_formspec(player_name, "miney:code_form", final_json_response)
     else
@@ -159,16 +223,84 @@ local function show_code_form(player_name, result_table, execution_id)
     return true
 end
 
+-- One scratch table per connected player, thrown away when they leave.
+--
+-- The sandbox used to be a single table shared by everyone, and it was also what the
+-- code wrote to. So `x = 1` in one script was still there in the next one, in every
+-- other player's scripts, and until the server restarted. `minetest = nil` - one typo
+-- away from `minetest = nil or something` - disabled the whole mod for the entire
+-- server, including Miney's own calls.
+--
+-- Reads still reach the shared environment through __index, so building it once is
+-- still worth it. Writes land in the player's own table and go away with them.
+local player_scratch = {}
+
+local function scratch_for(player_name)
+    local scratch = player_scratch[player_name]
+    if not scratch then
+        scratch = setmetatable({}, {__index = cached_env})
+        player_scratch[player_name] = scratch
+    end
+    return scratch
+end
+
+minetest.register_on_leaveplayer(function(player)
+    player_scratch[player:get_player_name()] = nil
+end)
+
+-- User code runs inside the server step, so for as long as it runs the whole server
+-- stands still - no player moves, nothing is saved. "while true do end" used to mean
+-- killing the process and losing whatever had not been written to disk yet.
+--
+-- The engine has no time limit to offer, but Lua counts instructions: a hook installed
+-- with the "count" mask fires every N of them, whatever the code is doing, and raising
+-- an error from inside it unwinds the call. The hook belongs to a coroutine, so the
+-- error stops that coroutine instead of the server step, and comes back through
+-- coroutine.resume in the same shape pcall would have returned.
+--
+-- Two things this depends on, both verified against a running server rather than
+-- assumed. LuaJIT does not check hooks inside a compiled trace, and "while true do end"
+-- is the first thing it compiles - with the hook alone the server froze exactly as
+-- before. jit.off(exec_func, true) keeps the user's code and everything it defines in
+-- the interpreter, where the hook fires. That costs nothing worth measuring here: these
+-- snippets spend their time inside engine calls, not in Lua arithmetic.
+--
+-- Not a hard guarantee: instructions are counted in Lua, not in C, so a single engine
+-- call that blocks for a minute still blocks for a minute. It catches the loop that a
+-- person actually writes by accident.
+--
+-- The budget is counted in Lua steps rather than seconds because that is what the hook
+-- offers. Measured on the test server: 20 million steps is about 0.02 s of frozen
+-- server and roughly 9 million iterations of a plain arithmetic loop. 200 million buys
+-- a tenth of a second in the worst case, which nobody notices, and leaves ten times the
+-- headroom for a script that genuinely has work to do.
+local INSTRUCTION_BUDGET = 200000000
+
+local function resume_with_budget(exec_func)
+    if jit and jit.off then
+        jit.off(exec_func, true)
+    end
+    local co = coroutine.create(exec_func)
+    debug.sethook(co, function()
+        debug.sethook(co)
+        error("Miney stopped this code after " .. INSTRUCTION_BUDGET .. " steps, to keep " ..
+              "the server responding. Is there a loop in it that never ends?", 2)
+    end, "", INSTRUCTION_BUDGET)
+    local success, result = coroutine.resume(co)
+    debug.sethook(co)
+    return success, result
+end
+
 -- Function to safely execute Lua code
-local function execute_lua_code(code)
+local function execute_lua_code(code, player_name)
     -- On the first run, build and cache the secure base environment.
     if not cached_env then
         log("action", "First run: Initializing and caching the secure Lua environment.")
         cached_env = {
             minetest = minetest,
+            storage = mod_storage,
             dump = dump,
             dump2 = dump2,
-            getfenv = getfenv,
             print = function(...)
                 local args = {...}
                 local result = ""
@@ -181,6 +313,11 @@ local function execute_lua_code(code)
             tostring = tostring,
             tonumber = tonumber,
             type = type,
+            -- No getfenv here on purpose. Lua 5.1 defines getfenv(0) as "the global
+            -- environment", so handing it out handed out the real _G: writable, shared
+            -- by every connection, and carrying io, os.remove and require. That made
+            -- the per-player scratch tables below decorative and gave anyone with the
+            -- 'miney' privilege read and write access to the server's file system.
             math = math,
             string = string,
             table = table,
@@ -233,10 +370,10 @@ local function execute_lua_code(code)
     local exec_func = factory_func()
 
     -- Now, directly set the environment of the final closure to our secure sandbox.
-    setfenv(exec_func, cached_env)
+    setfenv(exec_func, scratch_for(player_name))
 
     -- Execute the code and catch errors.
-    local success, result = pcall(exec_func)
+    local success, result = resume_with_budget(exec_func)
 
     if not success then
         return {error = "Runtime error: " .. tostring(result)}
@@ -283,7 +420,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
         local execution_id = fields.execution_id
         if fields.execute and fields.lua and fields.lua ~= "" then
-            local result_table = execute_lua_code(fields.lua)
+            local result_table = execute_lua_code(fields.lua, player_name)
             if execution_id then
                 result_table.execution_id = execution_id
             end
@@ -308,8 +445,7 @@ minetest.register_chatcommand("miney", {
             show_code_form(name)
             return true
         elseif command == "callbacks" then
-            local client_info = minetest.get_player_information(name) or {}
-            if client_info and client_info.version_string == "miney_v1.0" then
+            if is_miney_client(name) then
                 -- Warm-up uses the code form now to keep expected formname aligned
                 show_code_form(name)
                 return true

--- a/mod_data/miney/player.lua
+++ b/mod_data/miney/player.lua
@@ -28,13 +28,26 @@ local default_player_animations = {
 --      - step_interval (number): The time between each animation step. (Default: 0.05)
 --      - animation (boolean): Whether to play walk/stand animations. (Default: true)
 --
-function smooth_move(player, params)
+-- @param owner (string) - The player name whose connection this animation belongs to.
+--   Its frames are registered under that name, so leaving cancels them. The sandbox
+--   binds this; a caller from mod code may leave it out.
+--
+function smooth_move(player, params, owner)
     -- Validate that there is something to do
     if not player or not params or
        (not params.destination and not params.distance and not params.look_at and not params.yaw and not params.pitch) then
         minetest.log("error", "[smooth_move] Invalid parameters: At least one action (destination, distance, look_at, yaw, pitch) is required.")
         return
     end
+
+    -- One animation per player, so a second call replaces the first instead of fighting
+    -- it. Both chains used to call set_pos every frame, from their own start position
+    -- captured at their own time, and the player drifted between the two paths without
+    -- reaching either. Teleporting away did not help either: the next frame recomputed
+    -- the position from the start the animation remembered and pulled the player back.
+    owner = owner or "(mod)"
+    local key = "move:" .. player:get_player_name()
+    miney_tasks.cancel_key(owner, key)
 
     -- Default values
     local duration = params.duration or 1.0
@@ -67,10 +80,20 @@ function smooth_move(player, params)
 
     -- Look direction
     if params.look_at then
-        local direction = vector.direction(start_pos, params.look_at)
+        -- Measured from where the player ends up, not from where they set off. Taking
+        -- it from start_pos aimed along the old sight line, so a camera that flew 34
+        -- nodes to look at a building arrived pointing past it - the further the
+        -- flight, the wider the miss. The instant path in Player.move does the same
+        -- thing for the same reason, and the two now agree.
+        local direction = vector.direction(target_pos or start_pos, params.look_at)
         local rotation = vector.dir_to_rotation(direction)
         target_yaw = rotation.y
-        target_pitch = rotation.x
+        -- Negated on purpose. vector.dir_to_rotation returns asin(direction.y), which
+        -- is positive when the direction points up, while set_look_vertical is
+        -- documented as "positive is downwards". Passing one to the other tilted the
+        -- camera the wrong way: a look_at 45 degrees above the player aimed 45 degrees
+        -- below instead, a 90 degree error, while the compass bearing was correct.
+        target_pitch = -rotation.x
         do_look = true
     else
         if params.yaw or params.pitch then
@@ -126,7 +149,7 @@ function smooth_move(player, params)
             player:set_look_vertical(start_pitch + step_pitch * current_step)
         end
 
-        minetest.after(step_interval, animation_step)
+        miney_tasks.after(owner, step_interval, animation_step, key)
     end
 
     -- Start animation

--- a/mod_data/miney/tasks.lua
+++ b/mod_data/miney/tasks.lua
@@ -1,0 +1,136 @@
+-- Somewhere to keep the handle that minetest.after hands back.
+--
+-- The engine can cancel a scheduled call - core.after returns a job table with
+-- job:cancel() (doc/lua_api.md) - but nobody ever kept it. A function that
+-- re-schedules itself therefore outlived the script that started it, the disconnect
+-- and the Python process; and because every connection has its own sandbox, a later
+-- session could not even read the variables the loop was built from. Only a server
+-- restart stopped it.
+--
+-- So every timer started on behalf of a connection is registered here under that
+-- connection's player name, and register_on_leaveplayer cancels whatever is left.
+--
+-- Deliberately not a global registry with a stop-the-world button: a timer belongs to
+-- the session that asked for it, and that is the only thing that may end it.
+
+miney_tasks = {}
+
+-- owner -> id -> {job = <what minetest.after returned>, key = <string or nil>}
+local jobs = {}
+local next_id = 0
+
+local function owned(owner)
+    local mine = jobs[owner]
+    if not mine then
+        mine = {}
+        jobs[owner] = mine
+    end
+    return mine
+end
+
+--- Schedule a function the way minetest.after does, but keep the handle.
+--
+-- The entry removes itself just before the function runs, so something that
+-- re-schedules itself registers again and the table holds one entry per live chain
+-- instead of one per frame ever scheduled.
+--
+-- @param owner (string) - The player name this timer belongs to.
+-- @param delay (number) - Seconds until the call, as for minetest.after.
+-- @param fn (function) - What to call.
+-- @param key (string or nil) - A name to cancel it by, see cancel_key.
+-- @param ... - Further arguments for fn, as for minetest.after.
+-- @return (table) - A handle with :cancel(), the same shape minetest.after returns.
+function miney_tasks.after(owner, delay, fn, key, ...)
+    next_id = next_id + 1
+    local id = next_id
+    local mine = owned(owner)
+    local entry = {key = key}
+    mine[id] = entry
+
+    local args = {n = select("#", ...), ...}
+    entry.job = minetest.after(delay, function()
+        mine[id] = nil
+        fn(unpack(args, 1, args.n))
+    end)
+
+    return {cancel = function() return miney_tasks.cancel(owner, id) end}
+end
+
+--- Cancel one timer.
+--
+-- @param owner (string) - The player name it was registered under.
+-- @param id (number) - Its id.
+-- @return (boolean) - True if there was something to cancel.
+function miney_tasks.cancel(owner, id)
+    local mine = jobs[owner]
+    local entry = mine and mine[id]
+    if not entry then return false end
+    mine[id] = nil
+    entry.job:cancel()
+    return true
+end
+
+--- Cancel every timer this owner registered under one key.
+--
+-- Cancelling is idempotent in the engine - job:cancel() replaces the function with an
+-- empty one - so a stale key costs nothing.
+--
+-- @param owner (string) - The player name.
+-- @param key (string) - The key given to after().
+-- @return (number) - How many were cancelled.
+function miney_tasks.cancel_key(owner, key)
+    local mine = jobs[owner]
+    if not mine then return 0 end
+    local count = 0
+    for id, entry in pairs(mine) do
+        if entry.key == key then
+            mine[id] = nil
+            entry.job:cancel()
+            count = count + 1
+        end
+    end
+    return count
+end
+
+--- Is anything still scheduled under this key?
+--
+-- @param owner (string) - The player name.
+-- @param key (string) - The key given to after().
+-- @return (boolean)
+function miney_tasks.busy(owner, key)
+    local mine = jobs[owner]
+    if not mine then return false end
+    for _, entry in pairs(mine) do
+        if entry.key == key then return true end
+    end
+    return false
+end
+
+--- Cancel everything one connection started.
+--
+-- @param owner (string) - The player name.
+-- @return (number) - How many were cancelled.
+function miney_tasks.stop_all(owner)
+    local mine = jobs[owner]
+    if not mine then return 0 end
+    jobs[owner] = nil
+    local count = 0
+    for _, entry in pairs(mine) do
+        entry.job:cancel()
+        count = count + 1
+    end
+    return count
+end
+
+-- The one thing that makes all of the above worth having. A Miney session always ends
+-- here, whether it disconnected properly, timed out or its process was killed, so
+-- there is no state a runaway loop can survive in.
+minetest.register_on_leaveplayer(function(player)
+    local name = player:get_player_name()
+    local count = miney_tasks.stop_all(name)
+    if count > 0 then
+        minetest.log("action", "[miney] Cancelled " .. count .. " timer(s) left by " .. name .. ".")
+    end
+end)
+
+return miney_tasks

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -6,8 +6,9 @@ from unittest.mock import Mock, MagicMock
 
 import pytest
 
+from miney import Point
 from miney.callback import Callback
-from miney.events import ChatMessageEvent
+from miney.events import ChatCommandEvent, ChatMessageEvent
 
 
 class MockClientState:
@@ -78,24 +79,27 @@ def test_register_first_handler_sends_to_server(callback_env):
     assert payload["events"] == ["chat_message"]
 
 
-def test_register_second_handler_does_not_send(callback_env):
+def test_each_handler_is_registered_separately(callback_env):
+    """The server knows every handler by name, so a second one is news to it."""
     # Arrange
     callback, mock_client = callback_env
-    callback.register("chat_message", Mock())  # First registration
-    mock_client.sent_formspec_responses.clear() # Clear initial send
+    first = callback.register("chat_message", Mock())
+    mock_client.sent_formspec_responses.clear()
 
     # Act
-    callback.register("chat_message", Mock())  # Second registration
+    second = callback.register("chat_message", Mock())
 
     # Assert
-    assert len(mock_client.sent_formspec_responses) == 0
+    payload = json.loads(mock_client.sent_formspec_responses[0]["fields"]["payload"])
+    assert payload["handler"] == second
+    assert second != first
 
 
 def test_unregister_last_handler_sends_to_server(callback_env):
     # Arrange
     callback, mock_client = callback_env
     handler = Mock()
-    callback.register("chat_message", handler)
+    token = callback.register("chat_message", handler)
     mock_client.sent_formspec_responses.clear()
 
     # Act
@@ -106,20 +110,22 @@ def test_unregister_last_handler_sends_to_server(callback_env):
     payload = json.loads(mock_client.sent_formspec_responses[0]["fields"]["payload"])
     assert payload["action"] == "unregister"
     assert payload["events"] == ["chat_message"]
+    assert payload["handler"] == token
 
 
 def test_dispatch_loop_calls_handler(callback_env):
     # Arrange
     callback, mock_client = callback_env
     handler_mock = Mock()
-    callback.register("chat_message", handler_mock)
-    
+    token = callback.register("chat_message", handler_mock)
+
     # Simulate receiving data from the server
     handler = mock_client.command_handler.get_handler("miney:code_form")
     raw_event = {
         "event": "chat_message",
-        "payload": {"name": "dev", "message": "testing"},
+        "payload": {"sender_name": "dev", "message": "testing"},
         "client_id": callback._client_id,
+        "handlers": [token],
         "ts": time.time(),
     }
 
@@ -134,6 +140,81 @@ def test_dispatch_loop_calls_handler(callback_env):
     assert arg.sender_name == "dev"
 
 
+class CollectingHandler:
+    """
+    A callable object that is falsy while it is empty - a collector, a queue, a counter.
+
+    Perfectly ordinary as a callback, and the reason `if handler:` is not the same
+    question as `if handler is not None:`.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, event):
+        self.calls.append(event)
+
+    def __len__(self):
+        return len(self.calls)
+
+
+def test_dispatch_loop_calls_a_command_handler(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+    handler_mock = Mock()
+    callback.register_command("testcmd", handler_mock)
+
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+    raw_event = {
+        "event": "chatcommand",
+        "payload": {"command_name": "testcmd", "issuer": "dev", "param": "open"},
+        "client_id": callback._client_id,
+        "ts": time.time(),
+    }
+
+    # Act
+    handler(json.dumps(raw_event))
+    time.sleep(0.1)  # Give dispatcher time to process
+
+    # Assert
+    handler_mock.assert_called_once()
+    arg = handler_mock.call_args[0][0]
+    assert isinstance(arg, ChatCommandEvent)
+    assert arg.command_name == "testcmd"
+    assert arg.param == "open"
+
+
+def test_a_command_handler_that_is_falsy_is_still_called(callback_env):
+    """
+    A handler is looked up by name, and finding one is not the same as it being truthy.
+
+    An empty collector answers `False` to `if handler:` and the event was dropped in
+    silence - and since it only fills up by being called, it stayed empty and stayed
+    dropped, for the whole run.
+    """
+    # Arrange
+    callback, mock_client = callback_env
+    collector = CollectingHandler()
+    callback.register_command("testcmd", collector)
+    assert not collector, "the trap: an empty collector is falsy"
+
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+    raw_event = {
+        "event": "chatcommand",
+        "payload": {"command_name": "testcmd", "issuer": "dev", "param": "open"},
+        "client_id": callback._client_id,
+        "ts": time.time(),
+    }
+
+    # Act
+    handler(json.dumps(raw_event))
+    time.sleep(0.1)
+
+    # Assert
+    assert len(collector.calls) == 1
+    assert collector.calls[0].param == "open"
+
+
 def test_handler_exception_is_caught(callback_env, caplog):
     # Arrange
     callback, mock_client = callback_env
@@ -141,14 +222,15 @@ def test_handler_exception_is_caught(callback_env, caplog):
     def failing_handler(event):
         raise ValueError("Something went wrong")
 
-    callback.register("chat_message", failing_handler)
-    
+    token = callback.register("chat_message", failing_handler)
+
     handler = mock_client.command_handler.get_handler("miney:code_form")
     # Provide a valid payload for ChatMessageEvent
     raw_event = {
         "event": "chat_message",
-        "payload": {"name": "test", "message": "test"},
+        "payload": {"sender_name": "test", "message": "test"},
         "client_id": callback._client_id,
+        "handlers": [token],
     }
 
     # Act
@@ -253,3 +335,188 @@ def test_handle_miney_callbacks_ignores_lua_result(callback_env):
 
     # Assert
     assert callback._events_queue.empty()
+
+
+def test_register_sends_the_filter_to_the_server(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+
+    # Act
+    token = callback.register("chat_message", Mock(), {"sender_name": "Steve"})
+
+    # Assert
+    payload = json.loads(mock_client.sent_formspec_responses[0]["fields"]["payload"])
+    assert payload["handler"] == token
+    assert payload["filter"] == {"sender_name": "Steve"}
+
+
+def test_register_without_a_filter_sends_none(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+
+    # Act
+    callback.register("chat_message", Mock())
+
+    # Assert
+    payload = json.loads(mock_client.sent_formspec_responses[0]["fields"]["payload"])
+    assert "filter" not in payload
+
+
+def test_register_with_an_unknown_filter_field_raises(callback_env):
+    # Arrange
+    callback, _ = callback_env
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="has no field 'sender'"):
+        callback.register("chat_message", Mock(), {"sender": "Steve"})
+
+
+def test_a_filter_on_a_position_raises(callback_env):
+    """
+    A filter is answered with '==' on the server, so a position can never match one.
+
+    It looks like the most natural filter there is - watch this spot - and before this
+    raised, the mod read the table as a list of accepted values, found none, and rejected
+    every event for the rest of the session without a word.
+    """
+    # Arrange
+    callback, _ = callback_env
+
+    # Act / Assert
+    for value in ({"x": 1, "y": 2, "z": 3}, Point(1, 2, 3), [], {}):
+        with pytest.raises(ValueError) as error:
+            callback.register("node_dug", Mock(), {"pos": value})
+        assert "string, a number, a boolean or a list" in str(error.value)
+
+
+def test_a_filter_may_be_a_value_or_a_list_of_values(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+
+    # Act
+    callback.register("node_dug", Mock(), {"node_name": "mcl_core:dirt"})
+    callback.register("node_dug", Mock(), {"node_name": ["mcl_core:dirt", "mcl_core:sand"]})
+    callback.register("player_punched", Mock(), {"damage": 2})
+    callback.register("player_leaves", Mock(), {"timed_out": True})
+
+    # Assert
+    assert len(mock_client.sent_formspec_responses) == 4
+
+
+def test_unknown_filter_field_error_names_the_real_ones(callback_env):
+    # Arrange
+    callback, _ = callback_env
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="It sends: message, sender_name"):
+        callback.register("chat_message", Mock(), {"sender": "Steve"})
+
+
+def test_two_handlers_keep_their_own_filters(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+
+    # Act
+    for_steve = callback.register("chat_message", Mock(), {"sender_name": "Steve"})
+    for_alex = callback.register("chat_message", Mock(), {"sender_name": "Alex"})
+
+    # Assert
+    sent = [json.loads(r["fields"]["payload"]) for r in mock_client.sent_formspec_responses]
+    assert {p["handler"]: p["filter"] for p in sent} == {
+        for_steve: {"sender_name": "Steve"},
+        for_alex: {"sender_name": "Alex"},
+    }
+
+
+def test_only_the_handler_the_event_names_runs(callback_env):
+    """The mod applied the filters and said who the event is for."""
+    # Arrange
+    callback, mock_client = callback_env
+    for_steve, for_alex = Mock(), Mock()
+    steve_token = callback.register("chat_message", for_steve, {"sender_name": "Steve"})
+    callback.register("chat_message", for_alex, {"sender_name": "Alex"})
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+
+    # Act
+    handler(json.dumps({
+        "event": "chat_message",
+        "payload": {"sender_name": "Steve", "message": "hi"},
+        "client_id": callback._client_id,
+        "handlers": [steve_token],
+    }))
+    time.sleep(0.1)
+
+    # Assert
+    for_steve.assert_called_once()
+    for_alex.assert_not_called()
+
+
+def test_an_event_for_two_handlers_reaches_both(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+    first, second = Mock(), Mock()
+    tokens = [
+        callback.register("chat_message", first),
+        callback.register("chat_message", second),
+    ]
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+
+    # Act
+    handler(json.dumps({
+        "event": "chat_message",
+        "payload": {"sender_name": "Steve", "message": "hi"},
+        "client_id": callback._client_id,
+        "handlers": tokens,
+    }))
+    time.sleep(0.1)
+
+    # Assert
+    first.assert_called_once()
+    second.assert_called_once()
+
+
+def test_an_event_for_a_handler_that_is_gone_is_dropped(callback_env, caplog):
+    """Unregistering and an event already on its way can cross in flight."""
+    # Arrange
+    callback, mock_client = callback_env
+    handler_mock = Mock()
+    token = callback.register("chat_message", handler_mock)
+    callback.unregister("chat_message", token)
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+
+    # Act
+    with caplog.at_level(logging.DEBUG):
+        handler(json.dumps({
+            "event": "chat_message",
+            "payload": {"sender_name": "Steve", "message": "hi"},
+            "client_id": callback._client_id,
+            "handlers": [token],
+        }))
+        time.sleep(0.1)
+
+    # Assert
+    handler_mock.assert_not_called()
+    assert "which is gone" in caplog.text
+
+
+def test_unregistering_one_handler_leaves_the_other(callback_env):
+    # Arrange
+    callback, mock_client = callback_env
+    going, staying = Mock(), Mock()
+    callback.register("chat_message", going)
+    staying_token = callback.register("chat_message", staying)
+    callback.unregister("chat_message", going)
+    handler = mock_client.command_handler.get_handler("miney:code_form")
+
+    # Act
+    handler(json.dumps({
+        "event": "chat_message",
+        "payload": {"sender_name": "Steve", "message": "hi"},
+        "client_id": callback._client_id,
+        "handlers": [staying_token],
+    }))
+    time.sleep(0.1)
+
+    # Assert
+    staying.assert_called_once()
+    going.assert_not_called()

--- a/tests/test_client_protocol_emulation.py
+++ b/tests/test_client_protocol_emulation.py
@@ -243,7 +243,17 @@ def test_connect_success_and_events(fake_server: FakeServer, monkeypatch):
     fake_server.push_show_formspec("miney:code_form", "hello-json-or-legacy")
     _wait_for(lambda: calls == ["hello-json-or-legacy"])
 
-    # death screen auto-respawn sends formspec response
+    # The death screen is answered only when auto_respawn is switched on. It is off by
+    # default because the miney mod's own formspec makes the server refuse the answer;
+    # a Miney session respawns through Lua instead (Luanti._get_up_again).
+    fake_server.push_show_formspec("__builtin:death", "dead")
+    # A second form behind it, so the wait ends only once the death screen has been
+    # handled - packets are processed in the order they arrive.
+    fake_server.push_show_formspec("miney:code_form", "after-death")
+    _wait_for(lambda: calls == ["hello-json-or-legacy", "after-death"])
+    assert not any(f[0] == "__builtin:death" for f in fake_server.recorded_inventory_fields)
+
+    client.state.auto_respawn = True
     fake_server.push_show_formspec("__builtin:death", "dead")
     _wait_for(lambda: any(f[0] == "__builtin:death" for f in fake_server.recorded_inventory_fields))
     formname, fields = next(f for f in fake_server.recorded_inventory_fields if f[0] == "__builtin:death")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,9 +3,11 @@ import time
 from datetime import datetime
 
 import pytest
+from miney import Point
 from miney.events import (
     create_event, ChatMessageEvent, PlayerJoinsEvent, PlayerLeavesEvent,
-    ChatCommandEvent, GenericEvent
+    ChatCommandEvent, GenericEvent, NodeDugEvent, NodePlacedEvent, NodePunchedEvent,
+    PlayerDiesEvent, PlayerHpChangedEvent, PlayerPunchedEvent
 )
 
 
@@ -23,7 +25,7 @@ def minimal_raw_event():
 def test_create_event_chat_message(minimal_raw_event):
     # Arrange
     minimal_raw_event["event"] = "chat_message"
-    minimal_raw_event["payload"] = {"name": "tester", "message": "hello"}
+    minimal_raw_event["payload"] = {"sender_name": "tester", "message": "hello"}
 
     # Act
     event = create_event(minimal_raw_event)
@@ -38,7 +40,7 @@ def test_create_event_chat_message(minimal_raw_event):
 def test_create_event_player_joins_new_player(minimal_raw_event):
     # Arrange
     minimal_raw_event["event"] = "player_joins"
-    minimal_raw_event["payload"] = {"name": "newbie", "last_login": None}
+    minimal_raw_event["payload"] = {"player_name": "newbie", "last_login": None}
 
     # Act
     event = create_event(minimal_raw_event)
@@ -53,7 +55,7 @@ def test_create_event_player_joins_returning_player(minimal_raw_event):
     # Arrange
     ts = 1672531200  # 2023-01-01 00:00:00 UTC
     minimal_raw_event["event"] = "player_joins"
-    minimal_raw_event["payload"] = {"name": "veteran", "last_login": ts}
+    minimal_raw_event["payload"] = {"player_name": "veteran", "last_login": ts}
 
     # Act
     event = create_event(minimal_raw_event)
@@ -68,7 +70,7 @@ def test_create_event_player_joins_returning_player(minimal_raw_event):
 def test_create_event_player_leaves(minimal_raw_event):
     # Arrange
     minimal_raw_event["event"] = "player_leaves"
-    minimal_raw_event["payload"] = {"name": "leaver", "timed_out": True}
+    minimal_raw_event["payload"] = {"player_name": "leaver", "timed_out": True}
 
     # Act
     event = create_event(minimal_raw_event)
@@ -83,7 +85,7 @@ def test_create_event_chat_command(minimal_raw_event):
     # Arrange
     minimal_raw_event["event"] = "chatcommand"
     minimal_raw_event["payload"] = {
-        "name": "mycmd",
+        "command_name": "mycmd",
         "issuer": "commander",
         "param": "some param"
     }
@@ -110,3 +112,136 @@ def test_create_event_generic_for_unknown_event(minimal_raw_event):
     assert isinstance(event, GenericEvent)
     assert event.name == "some_new_unsupported_event"
     assert event.raw_payload == {"foo": "bar"}
+
+
+def test_event_fields_lists_what_a_filter_may_match():
+    from miney.events import EVENT_FIELDS
+
+    assert EVENT_FIELDS["chat_message"] == {"sender_name", "message"}
+    assert EVENT_FIELDS["player_joins"] == {"player_name", "last_login"}
+    assert EVENT_FIELDS["player_leaves"] == {"player_name", "timed_out"}
+    assert EVENT_FIELDS["node_dug"] == {"pos", "node_name", "player_name"}
+    assert EVENT_FIELDS["player_hp_changed"] == {"player_name", "hp_change", "hp", "reason"}
+
+
+@pytest.mark.parametrize("event_name, event_class", [
+    ("node_dug", NodeDugEvent),
+    ("node_placed", NodePlacedEvent),
+    ("node_punched", NodePunchedEvent),
+])
+def test_a_node_event_arrives_with_a_point(minimal_raw_event, event_name, event_class):
+    """The position travels as three numbers and has to arrive as something usable."""
+    # Arrange
+    minimal_raw_event["event"] = event_name
+    minimal_raw_event["payload"] = {
+        "pos": {"x": 10, "y": 20, "z": -30},
+        "node_name": "mcl_core:dirt",
+        "player_name": "tester",
+    }
+
+    # Act
+    event = create_event(minimal_raw_event)
+
+    # Assert
+    assert isinstance(event, event_class)
+    assert isinstance(event.pos, Point)
+    assert (event.pos.x, event.pos.y, event.pos.z) == (10, 20, -30)
+    assert event.node_name == "mcl_core:dirt"
+    assert event.player_name == "tester"
+
+
+def test_a_node_event_without_a_digger_carries_an_empty_name(minimal_raw_event):
+    """Falling gravel and mods dig too, and neither has a player name."""
+    # Arrange
+    minimal_raw_event["event"] = "node_dug"
+    minimal_raw_event["payload"] = {
+        "pos": {"x": 0, "y": 0, "z": 0}, "node_name": "mcl_core:sand", "player_name": "",
+    }
+
+    # Act
+    event = create_event(minimal_raw_event)
+
+    # Assert
+    assert event.player_name == ""
+
+
+def test_create_event_player_dies(minimal_raw_event):
+    # Arrange
+    minimal_raw_event["event"] = "player_dies"
+    minimal_raw_event["payload"] = {"player_name": "tester", "reason": "fall"}
+
+    # Act
+    event = create_event(minimal_raw_event)
+
+    # Assert
+    assert isinstance(event, PlayerDiesEvent)
+    assert event.player_name == "tester"
+    assert event.reason == "fall"
+
+
+def test_create_event_player_hp_changed(minimal_raw_event):
+    # Arrange
+    minimal_raw_event["event"] = "player_hp_changed"
+    minimal_raw_event["payload"] = {
+        "player_name": "tester", "hp_change": -4, "hp": 16, "reason": "punch",
+    }
+
+    # Act
+    event = create_event(minimal_raw_event)
+
+    # Assert
+    assert isinstance(event, PlayerHpChangedEvent)
+    assert event.hp_change == -4
+    assert event.hp == 16
+    assert event.reason == "punch"
+
+
+def test_create_event_player_punched(minimal_raw_event):
+    # Arrange
+    minimal_raw_event["event"] = "player_punched"
+    minimal_raw_event["payload"] = {
+        "player_name": "victim", "hitter_name": "", "damage": 2,
+    }
+
+    # Act
+    event = create_event(minimal_raw_event)
+
+    # Assert
+    assert isinstance(event, PlayerPunchedEvent)
+    assert event.hitter_name == "", "a mob has no name"
+    assert event.damage == 2
+
+
+def test_the_mod_and_python_agree_on_the_event_fields():
+    """
+    Both halves spell the payload fields, and a disagreement is invisible at runtime:
+    the handler would simply be called with defaults and a filter would match nothing.
+    """
+    import re
+    from pathlib import Path
+
+    from miney.events import EVENT_FIELDS
+
+    from miney.callback import Callback
+
+    lua = (Path(__file__).parent.parent / "mod_data" / "miney" / "callbacks.lua").read_text(
+        encoding="utf-8"
+    )
+    # The registrar is `on = minetest.register_on_something` for most events and a small
+    # function for the one that needs an extra argument, so the match runs from the entry
+    # name to its `keys`, whatever stands between them.
+    entries = re.findall(
+        r"(\w+) = \{\s*(?:--[^\n]*\n\s*)*on = .*?keys = \{([^}]*)\}", lua, re.S
+    )
+    assert entries, "No EVENTS entries found in callbacks.lua - did the table change shape?"
+
+    names = {name for name, _ in entries}
+    assert names == Callback.SUPPORTED_EVENTS, (
+        "The mod and Miney disagree about which events exist: "
+        f"only in the mod {sorted(names - Callback.SUPPORTED_EVENTS)}, "
+        f"only in Python {sorted(Callback.SUPPORTED_EVENTS - names)}"
+    )
+
+    for name, keys in entries:
+        in_lua = {key.strip().strip('"') for key in keys.split(",") if key.strip()}
+        assert in_lua == set(EVENT_FIELDS[name]), f"'{name}' differs between the two halves"

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,96 @@
+"""Inventory builds its Lua from quoted values, and answers with a list either way."""
+from __future__ import annotations
+import pytest
+
+from miney.inventory import Inventory
+from miney.lua import Lua
+from miney.node import Node
+from miney.player import Player
+
+
+class _RecordingLua:
+    """Records the Lua it is given, and quotes with the real dumps()."""
+
+    def __init__(self, answer=None) -> None:
+        self.calls: list[str] = []
+        self.answer = answer
+
+    def run(self, code, timeout=None):
+        self.calls.append(code)
+        return self.answer
+
+    def dumps(self, value):
+        return Lua.dumps(self, value)
+
+
+class _FakeLuanti:
+    def __init__(self, answer=None) -> None:
+        self.lua = _RecordingLua(answer)
+
+
+def _player(name: str) -> Player:
+    """A Player without its __init__, which reads the account off a server."""
+    p = Player.__new__(Player)
+    p.name = name
+    return p
+
+
+@pytest.fixture
+def player_inventory() -> Inventory:
+    return Inventory(_FakeLuanti(), _player("Steve"))
+
+
+def test_add_and_remove_reach_the_right_inventory(player_inventory):
+    lua = player_inventory.lt.lua
+
+    player_inventory.add("mcl_core:apple", 5)
+    assert 'name="Steve"' in lua.calls[-1]
+    assert 'ItemStack("mcl_core:apple 5")' in lua.calls[-1]
+
+    player_inventory.remove("mcl_core:apple", 5)
+    assert "remove_item" in lua.calls[-1]
+
+
+def test_a_node_inventory_is_found_by_position():
+    inv = Inventory(_FakeLuanti(), Node(1, -2, 3, name="mcl_chests:chest"))
+    inv.add("mcl_core:diamond")
+    assert 'type="node"' in inv.lt.lua.calls[-1]
+    assert "x=1" in inv.lt.lua.calls[-1] and "y=-2" in inv.lt.lua.calls[-1]
+
+
+@pytest.mark.parametrize("hostile", [
+    'evil") minetest.chat_send_all("PWNED',
+    'quote " and \\ backslash',
+    "newline\nand return\r",
+])
+def test_a_hostile_item_name_stays_one_string(player_inventory, hostile):
+    """It used to go into the Lua source unquoted, so it could close the call."""
+    player_inventory.add(hostile, 1)
+    code = player_inventory.lt.lua.calls[-1]
+
+    # Whatever it contained, the generated Lua is still a single add_item call.
+    assert code.count("add_item") == 1
+    assert "chat_send_all" not in code.replace(
+        player_inventory.lt.lua.dumps(f"{hostile} 1"), ""
+    )
+
+
+def test_a_hostile_player_name_stays_one_string():
+    inv = Inventory(_FakeLuanti(), _player('Bob") os.exit("'))
+    inv.add("mcl_core:apple")
+    assert "os.exit" not in inv.lt.lua.calls[-1].replace(
+        inv.lt.lua.dumps('Bob") os.exit("'), ""
+    )
+
+
+def test_a_hostile_list_name_stays_one_string():
+    inv = Inventory(_FakeLuanti([]), _player("Steve"))
+    inv.get_list('main") or error("')
+    assert inv.lt.lua.calls[-1].count("get_list") == 1
+
+
+def test_an_empty_inventory_answers_with_a_list_not_none():
+    """An empty Lua table arrives as None, and an empty chest is normal."""
+    inv = Inventory(_FakeLuanti(answer=None), _player("Steve"))
+    assert inv.get_list() == []
+    assert inv.get_lists() == []

--- a/tests/test_loud_failures.py
+++ b/tests/test_loud_failures.py
@@ -1,0 +1,138 @@
+"""Inputs that used to be ignored in silence now say what is wrong.
+
+Every case here returned ``None``, ``[]`` or simply did nothing before, so a script
+carried on believing it had placed its blocks.
+"""
+from __future__ import annotations
+import pytest
+
+import miney
+from miney.inventory import Inventory
+from miney.node import Node
+from miney.nodes import Nodes
+from miney.player import PlayerIterable
+from miney.point import Point
+
+
+class _FakeLua:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run(self, code, timeout=None):
+        self.calls.append(code)
+        return []
+
+    def dumps(self, value):
+        return repr(value)
+
+
+class _FakeLuanti:
+    def __init__(self) -> None:
+        self.lua = _FakeLua()
+
+
+@pytest.fixture
+def nodes() -> Nodes:
+    """A Nodes whose __init__ is skipped - it reads the node list off a server."""
+    n = Nodes.__new__(Nodes)
+    n.lt = _FakeLuanti()
+    return n
+
+
+@pytest.fixture
+def players() -> PlayerIterable:
+    p = PlayerIterable.__new__(PlayerIterable)
+    p._PlayerIterable__online_players = ["Steve", "Ana"]
+    p._PlayerIterable__mt = _FakeLuanti()
+    return p
+
+
+def _placed(nodes: Nodes) -> int:
+    return nodes.lt.lua.calls[-1].count("minetest.set_node") if nodes.lt.lua.calls else 0
+
+
+def test_set_accepts_any_collection(nodes):
+    a = Node(1, 2, 3, name="default:stone")
+    b = Node(4, 5, 6, name="default:stone")
+
+    nodes.set(a)
+    assert _placed(nodes) == 1
+
+    nodes.set([a, b])
+    assert _placed(nodes) == 2
+
+    nodes.set((a, b))  # a tuple used to place nothing at all
+    assert _placed(nodes) == 2
+
+    nodes.set(n for n in (a, b))  # a generator is walked twice internally
+    assert _placed(nodes) == 2
+
+
+def test_set_accepts_a_node_subclass(nodes):
+    class MyNode(Node):
+        pass
+
+    nodes.set(MyNode(1, 2, 3, name="default:stone"))
+    assert _placed(nodes) == 1
+
+
+def test_set_of_nothing_costs_no_round_trip(nodes):
+    nodes.set([])
+    assert nodes.lt.lua.calls == []
+
+
+@pytest.mark.parametrize("bad", ["default:dirt", 42, None, {"name": "x"}])
+def test_set_rejects_what_is_not_a_node(nodes, bad):
+    with pytest.raises(TypeError, match=type(bad).__name__):
+        nodes.set(bad)
+
+
+def test_set_rejects_a_point_among_the_nodes(nodes):
+    with pytest.raises(TypeError, match="Point"):
+        nodes.set([Node(1, 2, 3), Point(4, 5, 6)])
+
+
+def test_get_rejects_the_wrong_number_of_corners(nodes):
+    with pytest.raises(ValueError, match="exactly two"):
+        nodes.get([Point(0, 0, 0), Point(1, 1, 1), Point(2, 2, 2)])
+
+
+@pytest.mark.parametrize("bad", ["somewhere", 42, None])
+def test_get_rejects_what_is_not_a_point(nodes, bad):
+    with pytest.raises(TypeError, match=type(bad).__name__):
+        nodes.get(bad)
+
+
+@pytest.mark.parametrize("call", ["add", "remove", "get_lists", "get_list"])
+def test_inventory_without_a_player_or_node_raises(call):
+    orphan = Inventory(_FakeLuanti(), parent="neither")
+    args = ("default:dirt",) if call in ("add", "remove") else ()
+    with pytest.raises(TypeError, match="only players and nodes"):
+        getattr(orphan, call)(*args)
+
+
+def test_unknown_player_names_who_is_online(players):
+    with pytest.raises(miney.PlayerNotFoundError) as excinfo:
+        players["Steev"]
+
+    message = str(excinfo.value)
+    assert "'Steev'" in message and "'Steve'" in message and "'Ana'" in message
+
+
+def test_unknown_player_is_still_an_index_error(players):
+    """Scripts written against the old IndexError have to keep working."""
+    with pytest.raises(IndexError):
+        players["Steev"]
+
+
+def test_an_out_of_range_index_stays_a_plain_index_error(players):
+    with pytest.raises(IndexError) as excinfo:
+        players[99]
+
+    assert not isinstance(excinfo.value, miney.PlayerNotFoundError)
+
+
+def test_unknown_player_on_an_empty_server(players):
+    players._PlayerIterable__online_players = []
+    with pytest.raises(miney.PlayerNotFoundError, match="Nobody is online"):
+        players["Steve"]

--- a/tests/test_lua_dumps.py
+++ b/tests/test_lua_dumps.py
@@ -48,3 +48,29 @@ def test_nested_structures_and_escaping(lua_for_dumps):
 def test_tuple_dump(lua_for_dumps: Lua):
     dumped = lua_for_dumps.dumps((1, "x"))
     assert dumped == '{1, "x"}'
+
+
+def test_control_characters_use_lua_escapes(lua_for_dumps: Lua):
+    """
+    Lua has no ``\\u`` escape. JSON writes one for every control character, and the
+    server answered such a string with a Lua syntax error.
+    """
+    assert lua_for_dumps.dumps("a\x00b") == '"a\\000b"'
+    assert lua_for_dumps.dumps("a\x1bb") == '"a\\027b"'
+    assert lua_for_dumps.dumps("a\x7fb") == '"a\\127b"'
+    assert "\\u" not in lua_for_dumps.dumps("".join(chr(c) for c in range(32)))
+
+    # The ones Lua names itself stay readable.
+    assert lua_for_dumps.dumps("a\nb\tc\rd") == '"a\\nb\\tc\\rd"'
+
+    # Three digits always, or "\1" before a literal "8" would read as "\18".
+    assert lua_for_dumps.dumps("\x018") == '"\\0018"'
+
+
+def test_backslashes_are_not_double_escaped(lua_for_dumps: Lua):
+    assert lua_for_dumps.dumps("a\\b") == '"a\\\\b"'
+    assert lua_for_dumps.dumps("\\u0000") == '"\\\\u0000"'
+
+
+def test_non_ascii_passes_through(lua_for_dumps: Lua):
+    assert lua_for_dumps.dumps("Höhle") == '"Höhle"'

--- a/tests/test_lua_mockserver.py
+++ b/tests/test_lua_mockserver.py
@@ -3,7 +3,7 @@ import json
 import pathlib
 import pytest
 from typing import Callable, Dict, Any
-from miney.lua import Lua
+from miney.lua import Lua, REQUIRED_MOD_API
 
 
 class _DummyState:
@@ -29,10 +29,13 @@ class MockLuanti:
     - Sends back JSON or legacy formspec content upon send_formspec_response()
     """
     def __init__(self, playername: str = "Tester", mode: str = "success",
-                 connected: bool = True, legacy: bool = False) -> None:
+                 connected: bool = True, legacy: bool = False,
+                 mod_api: int | None = REQUIRED_MOD_API) -> None:
         self.playername = playername
         self.mode = mode
         self.legacy = legacy
+        #: What the mod claims to speak. None emulates a mod from before the handshake.
+        self.mod_api = mod_api
         self.command_handler = _DummyCommandHandler()
         self.state = _DummyState(connected=connected, state_value=999)
         self.sent_messages: list[str] = []
@@ -44,7 +47,10 @@ class MockLuanti:
         if message.strip() == "/miney form":
             handler = self.command_handler.handlers.get("miney:code_form")
             if handler:
-                handler("null")  # JSON null -> marks form as ready, nothing stored
+                # A current mod answers the warm-up with its API number and nothing
+                # else; one from before the handshake answers with JSON null.
+                handler("null" if self.mod_api is None
+                        else json.dumps({"mod_api": self.mod_api}))
         return True
 
     def send_formspec_response(self, formname: str, fields: dict) -> bool:
@@ -123,6 +129,56 @@ def test_run_regular_error_raises():
     with pytest.raises(Exception) as exc:
         lua.run("return 0")
     assert "boom" in str(exc.value)
+
+
+def test_run_refuses_a_mod_from_before_the_handshake():
+    """The failure this replaces was a nil index inside the user's own Lua."""
+    client = MockLuanti(mode="success", legacy=False, mod_api=None)
+    lua = Lua(client)
+
+    with pytest.raises(Exception) as exc:
+        lua.run("return 1")
+    message = str(exc.value)
+    assert "too old" in message
+    assert "miney upgrade" in message
+    assert not client.sent_fields  # refused before any code went out
+
+
+def test_run_refuses_a_mod_that_is_behind():
+    client = MockLuanti(mode="success", legacy=False, mod_api=REQUIRED_MOD_API - 1)
+    lua = Lua(client)
+
+    with pytest.raises(Exception) as exc:
+        lua.run("return 1")
+    assert f"speaks version {REQUIRED_MOD_API - 1}" in str(exc.value)
+
+
+def test_run_accepts_a_newer_mod():
+    """A mod ahead of us still speaks what we know, so it must not be refused."""
+    client = MockLuanti(mode="success", legacy=False, mod_api=REQUIRED_MOD_API + 5)
+    lua = Lua(client)
+
+    assert lua.run("return 1") == 42
+
+
+def test_run_refuses_code_over_the_formspec_limit():
+    """
+    Oversized submits are dropped by the server without an answer, so the client has
+    to catch them - otherwise the only symptom is a timeout with no reason in it.
+    """
+    from miney.lua import FORMSPEC_FIELD_LIMIT
+
+    client = MockLuanti(mode="success", legacy=False)
+    lua = Lua(client)
+
+    with pytest.raises(Exception) as exc:
+        lua.run("local s = " + '"' + "x" * FORMSPEC_FIELD_LIMIT + '"')
+    assert "too long to send" in str(exc.value)
+    assert not lua.pending_lua_results
+
+    # Just under the limit still goes out. The other fields cost a few bytes too, so
+    # leave room for them rather than testing the exact boundary.
+    assert lua.run("--" + "x" * (FORMSPEC_FIELD_LIMIT - 200)) == 42
 
 
 def test_run_timeout_raises_fast():

--- a/tests/test_luanti.py
+++ b/tests/test_luanti.py
@@ -1,6 +1,6 @@
 import logging
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from miney import luanti
@@ -96,3 +96,79 @@ def test_registering_a_new_player_is_not_a_warning(
         "registered" in record.message.lower() and record.levelno == logging.INFO
         for record in caplog.records
     )
+
+
+@patch("miney.luanti.LuantiClient")
+@patch("miney.luanti.Lua")
+@patch("miney.luanti.Chat")
+@patch("miney.luanti.Nodes")
+@patch("miney.luanti.ToolIterable")
+@patch("miney.luanti.Callback")
+def test_a_session_watches_its_own_player_dying(
+    MockCallback, MockToolIterable, MockNodes, MockChat, MockLua, MockLuantiClient
+):
+    """
+    Miney's player has to come back after it died, so every session subscribes to its
+    own death - and to nobody else's, or a script would resurrect the person playing.
+    """
+    lt = luanti.Luanti(server="test.server", playername="bot", password="pwd")
+
+    registered = MockCallback.return_value.register.call_args_list
+    assert ("player_dies", lt._get_up_again, {"player_name": "bot"}) in [
+        call.args for call in registered
+    ]
+
+
+def test_a_dead_miney_player_gets_up_again():
+    """
+    The respawn goes through Lua: the client's answer to the death screen is dropped by
+    the server whenever the mod has shown its own form in between, which is nearly
+    always. Invisibility is put back on, because respawning re-skins the player.
+    """
+    lt = luanti.Luanti.__new__(luanti.Luanti)
+    lt.playername = "bot"
+    lt._invisible = True
+    lt._lua = MagicMock()
+    lt._lua.dumps.side_effect = lambda value: f'"{value}"'
+    bot = MagicMock()
+
+    with patch.object(luanti.Luanti, "players", new_callable=PropertyMock) as players:
+        players.return_value = {"bot": bot}
+        lt._get_up_again(object())
+
+    code = lt._lua.run.call_args.args[0]
+    assert '"bot"' in code and "respawn()" in code
+    assert bot.invisible is True
+
+
+def test_a_visible_miney_player_stays_visible_after_respawning():
+    """A session started with invisible=False must not be hidden by a death."""
+    lt = luanti.Luanti.__new__(luanti.Luanti)
+    lt.playername = "bot"
+    lt._invisible = False
+    lt._lua = MagicMock()
+    lt._lua.dumps.side_effect = lambda value: f'"{value}"'
+
+    with patch.object(luanti.Luanti, "players", new_callable=PropertyMock) as players:
+        lt._get_up_again(object())
+
+    players.assert_not_called()
+    assert "respawn()" in lt._lua.run.call_args.args[0]
+
+
+def test_a_failing_respawn_does_not_reach_the_event_dispatcher(caplog):
+    """
+    This runs on the callback dispatcher thread. An exception there kills nothing but
+    is invisible, so it is logged instead.
+    """
+    lt = luanti.Luanti.__new__(luanti.Luanti)
+    lt.playername = "bot"
+    lt._invisible = False
+    lt._lua = MagicMock()
+    lt._lua.dumps.return_value = '"bot"'
+    lt._lua.run.side_effect = RuntimeError("server gone")
+
+    with caplog.at_level(logging.ERROR, logger="miney.luanti"):
+        lt._get_up_again(object())
+
+    assert any("server gone" in record.getMessage() for record in caplog.records)

--- a/tests/test_luanti_env.py
+++ b/tests/test_luanti_env.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import argparse
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,9 @@ def no_real_connection(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
+        def register(self, *args, **kwargs):
+            return "token"
+
         def shutdown(self):
             return None
 
@@ -104,12 +108,109 @@ def test_several_worlds_require_naming_one(tmp_path, monkeypatch, no_real_connec
     paths = EnvPaths(root=tmp_path / ".miney")
     save_state(paths.state_file("alpha"), WorldState("alpha", "minetest_game", 30000))
     save_state(paths.state_file("beta"), WorldState("beta", "mineclone2", 30001))
+    monkeypatch.setattr(manage, "is_server_up", lambda state: False)
 
     with pytest.raises(MineyRunError) as error:
         luanti_module.Luanti(autostart=False)
 
     assert "alpha" in str(error.value)
     assert "beta" in str(error.value)
+
+
+def test_the_running_world_is_the_one_that_is_meant(tmp_path, monkeypatch,
+                                                    no_real_connection):
+    """
+    A second world must not take the answer away from a script that worked yesterday.
+
+    This is the whole point of the rule: a test world, a tutorial world or a world left
+    over from an experiment sits on disk beside the one being worked in, and the one
+    that is *running* is obviously the one meant.
+    """
+    monkeypatch.chdir(tmp_path)
+    paths = EnvPaths(root=tmp_path / ".miney")
+    save_state(paths.state_file("alpha"), WorldState("alpha", "minetest_game", 30000))
+    save_state(paths.state_file("beta"), WorldState("beta", "mineclone2", 30001))
+    monkeypatch.setattr(manage, "is_server_up", lambda state: state.name == "beta")
+
+    lt = luanti_module.Luanti(autostart=False)
+
+    assert lt.port == 30001
+
+
+def test_a_bare_start_reuses_a_world_instead_of_inventing_one(tmp_path, monkeypatch):
+    """
+    'miney start' with several worlds and none running must not create a new one.
+
+    It used to fall through to the world named after the default game, which with two
+    worlds already there meant a *third* one: a first start, a full map generation, and
+    minutes of waiting for a world nobody asked for.
+    """
+    monkeypatch.chdir(tmp_path)
+    paths = EnvPaths(root=tmp_path / ".miney")
+    for name, game, port in (("alpha", "minetest_game", 30000),
+                             ("beta", "mineclone2", 30001)):
+        save_state(paths.state_file(name), WorldState(name, game, port))
+        (paths.world_dir(name)).mkdir(parents=True, exist_ok=True)
+        (paths.world_dir(name) / "world.mt").write_text(f"gameid = {game}\n",
+                                                        encoding="utf-8")
+    monkeypatch.setattr(manage, "is_server_up", lambda state: False)
+    # 'beta' was worked in last.
+    later = paths.state_file("alpha").stat().st_mtime + 60
+    import os
+    os.utime(paths.state_file("beta"), (later, later))
+
+    args = argparse.Namespace(world=None, game=None)
+    world, game = cli_module._resolve_world_and_game(paths, args)
+
+    assert (world, game) == ("beta", "mineclone2")
+
+
+def test_a_named_port_picks_the_world_on_it(tmp_path, monkeypatch, no_real_connection):
+    monkeypatch.chdir(tmp_path)
+    paths = EnvPaths(root=tmp_path / ".miney")
+    save_state(paths.state_file("alpha"), WorldState("alpha", "minetest_game", 30000))
+    save_state(paths.state_file("beta"), WorldState("beta", "mineclone2", 30001))
+    monkeypatch.setattr(manage, "is_server_up", lambda state: True)
+
+    lt = luanti_module.Luanti(port=30001, autostart=False)
+
+    assert lt.port == 30001
+
+
+def test_several_running_worlds_are_all_named_in_the_error(tmp_path, monkeypatch,
+                                                           no_real_connection):
+    monkeypatch.chdir(tmp_path)
+    paths = EnvPaths(root=tmp_path / ".miney")
+    save_state(paths.state_file("alpha"), WorldState("alpha", "minetest_game", 30000))
+    save_state(paths.state_file("beta"), WorldState("beta", "mineclone2", 30001))
+    monkeypatch.setattr(manage, "is_server_up", lambda state: True)
+
+    with pytest.raises(MineyRunError) as error:
+        luanti_module.Luanti(autostart=False)
+
+    message = str(error.value)
+    assert "running" in message
+    assert "alpha" in message and "beta" in message
+
+
+def test_the_error_suggests_the_world_used_last(tmp_path, monkeypatch,
+                                                no_real_connection):
+    """Not the first one alphabetically - that is the throwaway world often enough."""
+    monkeypatch.chdir(tmp_path)
+    paths = EnvPaths(root=tmp_path / ".miney")
+    save_state(paths.state_file("alpha"), WorldState("alpha", "minetest_game", 30000))
+    save_state(paths.state_file("beta"), WorldState("beta", "mineclone2", 30001))
+    monkeypatch.setattr(manage, "is_server_up", lambda state: False)
+    # 'beta' was written a minute later than 'alpha'.
+    import os
+    later = paths.state_file("alpha").stat().st_mtime + 60
+    os.utime(paths.state_file("beta"), (later, later))
+
+    with pytest.raises(MineyRunError) as error:
+        luanti_module.Luanti(autostart=False)
+
+    assert 'miney.Luanti(world="beta")' in str(error.value)
+    assert "miney start --world beta" in str(error.value)
 
 
 def test_named_world_is_selected(tmp_path, monkeypatch, no_real_connection):

--- a/tests/test_nodes_fill.py
+++ b/tests/test_nodes_fill.py
@@ -1,0 +1,124 @@
+"""lt.nodes.fill: the box it describes, and the slabs it is cut into."""
+from __future__ import annotations
+import pytest
+
+from miney.nodes import Nodes, _slabs, _MAX_FILL_VOLUME
+from miney.node import Node
+from miney.point import Point
+
+
+class _FakeLua:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run(self, code, timeout=None):
+        self.calls.append(code)
+        # The real Lua returns how many blocks it wrote; the box is in the source.
+        p1 = [int(code.split(f"{axis} = ")[1].split(",")[0].split("}")[0])
+              for axis in ("x", "y", "z")]
+        p2 = [int(code.split(f"{axis} = ")[2].split(",")[0].split("}")[0])
+              for axis in ("x", "y", "z")]
+        return (p2[0] - p1[0] + 1) * (p2[1] - p1[1] + 1) * (p2[2] - p1[2] + 1)
+
+    def dumps(self, value):
+        return repr(value)
+
+
+class _FakeLuanti:
+    def __init__(self) -> None:
+        self.lua = _FakeLua()
+
+
+@pytest.fixture
+def nodes() -> Nodes:
+    n = Nodes.__new__(Nodes)
+    n.lt = _FakeLuanti()
+    n._names_cache = ["air", "mcl_core:obsidian", "mcl_core:stone"]
+    return n
+
+
+def _volume(box) -> int:
+    (x1, y1, z1), (x2, y2, z2) = box
+    return (x2 - x1 + 1) * (y2 - y1 + 1) * (z2 - z1 + 1)
+
+
+def _cells(box) -> set:
+    (x1, y1, z1), (x2, y2, z2) = box
+    return {(x, y, z)
+            for x in range(x1, x2 + 1)
+            for y in range(y1, y2 + 1)
+            for z in range(z1, z2 + 1)}
+
+
+@pytest.mark.parametrize("p1, p2", [
+    ((0, 0, 0), (0, 0, 0)),
+    ((0, 0, 0), (9, 4, 9)),
+    ((-5, -5, -5), (5, 5, 5)),
+    ((0, 0, 0), (99, 0, 99)),
+])
+def test_small_boxes_are_one_slab_and_cover_themselves(p1, p2):
+    boxes = list(_slabs(p1, p2))
+    assert len(boxes) == 1
+    assert _cells(boxes[0]) == _cells((p1, p2))
+
+
+def test_a_big_box_is_cut_up_and_still_covers_exactly():
+    p1, p2 = (0, 0, 0), (299, 99, 299)          # 9,000,000 blocks
+    boxes = list(_slabs(p1, p2))
+
+    assert len(boxes) > 1, "should have been split"
+    assert all(_volume(b) <= _MAX_FILL_VOLUME for b in boxes), "a slab is too big"
+    assert sum(_volume(b) for b in boxes) == 300 * 100 * 300, "gap or overlap"
+
+    seen = set()
+    for box in boxes:                            # no cell twice
+        cells = _cells(box)
+        assert not (cells & seen)
+        seen |= cells
+    assert len(seen) == 300 * 100 * 300
+
+
+def test_a_box_too_wide_for_one_layer_is_cut_along_y_as_well():
+    """dx*dy alone exceeds the budget, so slicing z is not enough."""
+    p1, p2 = (0, 0, 0), (2999, 2999, 1)
+    boxes = list(_slabs(p1, p2))
+
+    assert all(_volume(b) <= _MAX_FILL_VOLUME for b in boxes)
+    assert sum(_volume(b) for b in boxes) == 3000 * 3000 * 2
+
+
+def test_fill_counts_every_block_of_a_split_box(nodes):
+    written = nodes.fill(Point(0, 0, 0), Point(299, 99, 299), "air")
+    assert written == 300 * 100 * 300
+    assert len(nodes.lt.lua.calls) > 1
+
+
+def test_the_corners_may_be_given_in_any_order(nodes):
+    forwards = nodes.fill(Point(0, 10, 0), Point(9, 14, 9), "air")
+    backwards = nodes.fill(Point(9, 14, 9), Point(0, 10, 0), "air")
+    assert forwards == backwards == 500
+    assert nodes.lt.lua.calls[-1] == nodes.lt.lua.calls[-2]
+
+
+def test_a_node_works_as_a_corner_because_it_is_a_point(nodes):
+    assert nodes.fill(Node(0, 0, 0), Node(1, 1, 1), "air") == 8
+
+
+def test_fractional_coordinates_are_floored_like_everywhere_else(nodes):
+    assert nodes.fill(Point(0.9, 0.9, 0.9), Point(1.9, 1.9, 1.9), "air") == 8
+
+
+def test_an_unknown_block_name_says_where_to_find_a_real_one(nodes):
+    with pytest.raises(ValueError, match="lt.nodes.names"):
+        nodes.fill(Point(0, 0, 0), Point(1, 1, 1), "mcl_core:obsidain")
+    assert nodes.lt.lua.calls == [], "it must not reach the server"
+
+
+@pytest.mark.parametrize("start, end, name", [
+    ((0, 0, 0), Point(1, 1, 1), "air"),
+    (Point(0, 0, 0), [1, 1, 1], "air"),
+    (Point(0, 0, 0), Point(1, 1, 1), 42),
+])
+def test_fill_rejects_the_wrong_kind_of_argument(nodes, start, end, name):
+    with pytest.raises(TypeError):
+        nodes.fill(start, end, name)

--- a/tests/test_nodes_get_encoding.py
+++ b/tests/test_nodes_get_encoding.py
@@ -1,0 +1,160 @@
+"""The packed form nodes.get() reads a region back in.
+
+The coordinates are not transmitted - they are rebuilt by walking the region in the
+same order the server walked it. Getting that walk wrong would put the right nodes at
+the wrong places, which is the kind of bug that looks like the world moved.
+"""
+from __future__ import annotations
+import pytest
+
+from miney.exceptions import DataError
+from miney.node import Node
+from miney.nodes import Nodes, _decode_nodes
+from miney.point import Point
+
+
+def _encode(names_by_position, corner1, corner2):
+    """Build the packed form the mod produces, so a decode can be checked against it."""
+    x1, y1, z1 = corner1
+    x2, y2, z2 = corner2
+    palette, index_of, runs = [], {}, []
+    last, run = None, 0
+    for x in range(x1, x2 + 1):
+        for y in range(y1, y2 + 1):
+            for z in range(z1, z2 + 1):
+                name, p1, p2 = names_by_position(x, y, z)
+                if name not in index_of:
+                    palette.append(name)
+                    index_of[name] = len(palette)
+                token = f"{index_of[name]},{p1},{p2}"
+                if token == last:
+                    run += 1
+                else:
+                    if last:
+                        runs.append(f"{last}x{run}")
+                    last, run = token, 1
+    if last:
+        runs.append(f"{last}x{run}")
+    return " ".join(palette) + "|" + " ".join(runs)
+
+
+def test_positions_come_back_in_x_outer_z_inner_order():
+    """The order nodes.get() has always returned. Scripts index into this list."""
+    corner1, corner2 = (0, 0, 0), (1, 1, 1)
+    packed = _encode(lambda x, y, z: (f"m:n{x}{y}{z}", 0, 0), corner1, corner2)
+
+    nodes = _decode_nodes(packed, corner1, corner2, luanti=None)
+
+    assert [(n.x, n.y, n.z) for n in nodes] == [
+        (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1),
+        (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1),
+    ]
+
+
+def test_a_run_that_crosses_row_and_layer_boundaries():
+    """One long run has to be unpacked across the z, y and x wraps."""
+    corner1, corner2 = (0, 0, 0), (2, 2, 2)
+    packed = "mcl_core:stone|1,0,0x27"
+
+    nodes = _decode_nodes(packed, corner1, corner2, luanti=None)
+
+    assert len(nodes) == 27
+    assert all(n.name == "mcl_core:stone" for n in nodes)
+    assert (nodes[0].x, nodes[0].y, nodes[0].z) == (0, 0, 0)
+    assert (nodes[13].x, nodes[13].y, nodes[13].z) == (1, 1, 1)
+    assert (nodes[-1].x, nodes[-1].y, nodes[-1].z) == (2, 2, 2)
+
+
+def test_params_and_several_names_survive():
+    corner1, corner2 = (5, -3, 7), (6, -3, 7)
+    packed = "air mcl_core:tree|1,15,0x1 2,4,13x1"
+
+    a, b = _decode_nodes(packed, corner1, corner2, luanti=None)
+
+    assert (a.name, a.param1, a.param2) == ("air", 15, 0)
+    assert (b.name, b.param1, b.param2) == ("mcl_core:tree", 4, 13)
+    assert (a.x, a.y, a.z) == (5, -3, 7)
+    assert (b.x, b.y, b.z) == (6, -3, 7)
+
+
+def test_negative_coordinates():
+    corner1, corner2 = (-2, -2, -2), (-1, -1, -1)
+    packed = "mcl_core:stone|1,0,0x8"
+
+    nodes = _decode_nodes(packed, corner1, corner2, luanti=None)
+
+    assert [(n.x, n.y, n.z) for n in nodes][0] == (-2, -2, -2)
+    assert [(n.x, n.y, n.z) for n in nodes][-1] == (-1, -1, -1)
+
+
+def test_a_single_node_region():
+    nodes = _decode_nodes("air|1,0,0x1", (3, 4, 5), (3, 4, 5), luanti=None)
+    assert len(nodes) == 1 and (nodes[0].x, nodes[0].y, nodes[0].z) == (3, 4, 5)
+
+
+def test_the_luanti_instance_is_bound_so_inventory_works():
+    sentinel = object()
+    nodes = _decode_nodes("air|1,0,0x1", (0, 0, 0), (0, 0, 0), luanti=sentinel)
+    assert nodes[0]._luanti is sentinel
+
+
+@pytest.mark.parametrize("packed, why", [
+    ("no separator here", "no pipe at all"),
+    ("air|1,0,0x7", "run count does not fill the region"),
+    ("air|1,0,0x1 1,0,0x1 1,0,0x1", "too many nodes"),
+    ("air|9,0,0x8", "palette index that does not exist"),
+    ("air|nonsense", "not a token"),
+    ("air|1,0x8", "token is missing a field"),
+])
+def test_a_malformed_answer_is_reported_not_guessed(packed, why):
+    with pytest.raises(DataError):
+        _decode_nodes(packed, (0, 0, 0), (1, 1, 1), luanti=None)
+
+
+class _FakeLua:
+    def __init__(self, answer) -> None:
+        self.answer = answer
+        self.calls = []
+
+    def run(self, code, timeout=None):
+        self.calls.append(code)
+        return self.answer
+
+    def dumps(self, value):
+        return repr(value)
+
+
+class _FakeLuanti:
+    def __init__(self, answer) -> None:
+        self.lua = _FakeLua(answer)
+
+
+def _nodes_with(answer) -> Nodes:
+    n = Nodes.__new__(Nodes)
+    n.lt = _FakeLuanti(answer)
+    return n
+
+
+def test_get_sorts_the_corners_before_walking_them():
+    """Given the far corner first, the region and the order must be the same."""
+    forwards = _nodes_with("mcl_core:stone|1,0,0x8")
+    backwards = _nodes_with("mcl_core:stone|1,0,0x8")
+
+    a = forwards.get([Point(0, 0, 0), Point(1, 1, 1)])
+    b = backwards.get([Point(1, 1, 1), Point(0, 0, 0)])
+
+    assert [(n.x, n.y, n.z) for n in a] == [(n.x, n.y, n.z) for n in b]
+    assert (a[0].x, a[0].y, a[0].z) == (0, 0, 0)
+
+
+def test_get_of_a_cuboid_is_one_round_trip():
+    nodes = _nodes_with("mcl_core:stone|1,0,0x1000")
+    result = nodes.get([Point(0, 0, 0), Point(9, 9, 9)])
+
+    assert len(result) == 1000
+    assert len(nodes.lt.lua.calls) == 1, "the whole region in one call"
+
+
+def test_a_node_counts_as_a_corner():
+    nodes = _nodes_with("air|1,0,0x8")
+    assert len(nodes.get([Node(0, 0, 0), Node(1, 1, 1)])) == 8

--- a/tests/test_player_move_wait.py
+++ b/tests/test_player_move_wait.py
@@ -1,0 +1,94 @@
+"""Waiting for a smooth move to finish.
+
+The server frame, not the duration, decides when an animation is over, so waiting is a
+question asked repeatedly rather than a sleep of the right length. These check that the
+question is asked, that it stops being asked, and that it is refused where there is
+nothing to wait for.
+"""
+from __future__ import annotations
+import pytest
+
+from miney.player import Player
+from miney.point import Point
+
+
+class _FakeLua:
+    """Answers ``miney_task_busy`` a fixed number of times with True."""
+
+    def __init__(self, busy_answers: int = 0) -> None:
+        self.busy_left = busy_answers
+        self.calls: list[str] = []
+
+    def run(self, code, timeout=None):
+        self.calls.append(code)
+        if "miney_task_busy" in code:
+            if self.busy_left > 0:
+                self.busy_left -= 1
+                return True
+            return False
+        return None
+
+    def dumps(self, value):
+        if isinstance(value, str):
+            return '"' + value + '"'
+        return repr(value)
+
+
+class _FakeLuanti:
+    def __init__(self, busy_answers: int = 0) -> None:
+        self.lua = _FakeLua(busy_answers)
+
+
+def _player(busy_answers: int = 0) -> Player:
+    p = Player.__new__(Player)
+    p.lt = _FakeLuanti(busy_answers)
+    p.name = "Steve"
+    return p
+
+
+@pytest.fixture(autouse=True)
+def no_real_sleeping(monkeypatch):
+    monkeypatch.setattr("miney.player.time.sleep", lambda seconds: None)
+
+
+def test_wait_without_smooth_is_refused():
+    with pytest.raises(ValueError, match="smooth=True"):
+        _player().move(destination=Point(1, 2, 3), wait=True)
+
+
+def test_a_smooth_move_without_wait_asks_nothing():
+    p = _player()
+    p.move(destination=Point(1, 2, 3), smooth=True, duration=2)
+
+    assert not any("miney_task_busy" in c for c in p.lt.lua.calls)
+
+
+def test_wait_asks_until_the_answer_is_no():
+    p = _player(busy_answers=3)
+    p.move(destination=Point(1, 2, 3), smooth=True, duration=2, wait=True)
+
+    asked = [c for c in p.lt.lua.calls if "miney_task_busy" in c]
+    assert len(asked) == 4, "three times busy, then once more to hear it is done"
+
+
+def test_the_key_names_this_player():
+    p = _player(busy_answers=1)
+    p.move(destination=Point(1, 2, 3), smooth=True, wait=True)
+
+    asked = [c for c in p.lt.lua.calls if "miney_task_busy" in c][0]
+    assert '"move:Steve"' in asked
+
+
+def test_the_animation_is_started_before_it_is_waited_for():
+    p = _player(busy_answers=1)
+    p.move(destination=Point(1, 2, 3), smooth=True, wait=True)
+
+    order = [("smooth_move" in c, "miney_task_busy" in c) for c in p.lt.lua.calls]
+    assert order[0] == (True, False)
+
+
+def test_an_instant_move_still_needs_no_animation():
+    p = _player()
+    p.move(destination=Point(1, 2, 3))
+
+    assert not any("smooth_move" in c for c in p.lt.lua.calls)

--- a/tests/test_reliable_send.py
+++ b/tests/test_reliable_send.py
@@ -1,0 +1,149 @@
+"""Reliable sending: the window, the retransmission and the giving up.
+
+A packet that is lost gets no acknowledgement, and Luanti deliberately stays silent
+about one that arrives too far ahead - `src/network/mtp/threads.cpp`: *"packet is not
+within receive window, don't send ack. if this was a valid packet it's gonna be
+retransmitted"*. So this is the half of the conversation Miney has to hold up. None of
+it is reachable over loopback, where nothing is ever lost.
+"""
+from __future__ import annotations
+import threading
+import time
+
+import pytest
+
+from miney.luanticlient import connection as conn_module
+from miney.luanticlient.connection import Connection, SEND_WINDOW, MAX_SEND_TRIES
+from miney.luanticlient.state import ClientStateHolder
+
+
+class _FakeSocket:
+    """Records what was sent, and can be told to swallow some of it."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.drop = set()          # indices of sendto calls to discard
+        self.calls = 0
+
+    def sendto(self, packet, addr):
+        self.calls += 1
+        if self.calls - 1 not in self.drop:
+            self.sent.append(packet)
+        return len(packet)
+
+
+@pytest.fixture
+def conn() -> Connection:
+    c = Connection("127.0.0.1", 30000, protocol=None, state=ClientStateHolder(),
+                   command_processor=lambda *a: None)
+    c.sock = _FakeSocket()
+    c.running = True
+    return c
+
+
+def _packet(n: int) -> bytes:
+    return f"packet-{n}".encode()
+
+
+def test_a_sent_packet_is_kept_until_it_is_acknowledged(conn):
+    assert conn._send_reliable(_packet(1), seqnum=100)
+    assert 100 in conn._unacked, "nothing to resend with if it never arrives"
+
+    conn._handle_ack(100)
+    assert conn._unacked == {}
+
+
+def test_an_unacknowledged_packet_is_sent_again(conn):
+    conn._send_reliable(_packet(1), seqnum=100)
+    assert conn.sock.calls == 1
+
+    conn._resend_expired()
+    assert conn.sock.calls == 1, "not before the timeout is up"
+
+    conn._unacked[100].sent_at -= conn_module.RESEND_TIMEOUT + 0.01
+    conn._resend_expired()
+    assert conn.sock.calls == 2
+    assert conn.sock.sent[-1] == _packet(1), "resent verbatim, same sequence number"
+
+
+def test_an_acknowledged_packet_is_never_sent_again(conn):
+    conn._send_reliable(_packet(1), seqnum=100)
+    conn._handle_ack(100)
+
+    conn._resend_expired()
+    assert conn.sock.calls == 1
+
+
+def test_it_gives_up_rather_than_resending_for_ever(conn):
+    conn._send_reliable(_packet(1), seqnum=100)
+
+    for _ in range(MAX_SEND_TRIES + 2):
+        if 100 in conn._unacked:
+            conn._unacked[100].sent_at -= conn_module.RESEND_TIMEOUT + 0.01
+        conn._resend_expired()
+
+    assert conn._unacked == {}, "a lost packet must not wedge the window for ever"
+    assert conn.sock.calls == MAX_SEND_TRIES
+
+
+def test_the_window_blocks_until_an_acknowledgement_arrives(conn):
+    for seqnum in range(SEND_WINDOW):
+        assert conn._send_reliable(_packet(seqnum), seqnum)
+    assert len(conn._unacked) == SEND_WINDOW
+
+    done = threading.Event()
+
+    def send_one_more():
+        conn._send_reliable(_packet(999), seqnum=999)
+        done.set()
+
+    waiter = threading.Thread(target=send_one_more, daemon=True)
+    waiter.start()
+
+    assert not done.wait(timeout=0.3), "a full window has to wait"
+    conn._handle_ack(0)
+    assert done.wait(timeout=2.0), "and go again as soon as a slot is free"
+    waiter.join(timeout=1.0)
+
+    assert 999 in conn._unacked
+
+
+def test_a_stopped_receiver_releases_a_blocked_sender(conn):
+    """Otherwise disconnecting during a big upload would hang on the window."""
+    for seqnum in range(SEND_WINDOW):
+        conn._send_reliable(_packet(seqnum), seqnum)
+
+    result = []
+    waiter = threading.Thread(
+        target=lambda: result.append(conn._send_reliable(_packet(999), 999)),
+        daemon=True)
+    waiter.start()
+    time.sleep(0.15)
+
+    conn.running = False
+    with conn._unacked_cond:
+        conn._unacked_cond.notify_all()
+
+    waiter.join(timeout=2.0)
+    assert result == [False], "the send reports failure instead of blocking for ever"
+
+
+def test_waiting_for_acks_returns_when_the_queue_empties(conn):
+    conn._send_reliable(_packet(1), seqnum=100)
+
+    threading.Timer(0.1, lambda: conn._handle_ack(100)).start()
+    t0 = time.monotonic()
+    conn._wait_for_acks(timeout=5.0)
+
+    assert conn._unacked == {}
+    assert time.monotonic() - t0 < 4.0, "it waited for the timeout instead of the ACK"
+
+
+def test_waiting_for_acks_gives_up_on_time(conn):
+    conn._send_reliable(_packet(1), seqnum=100)
+
+    t0 = time.monotonic()
+    conn._wait_for_acks(timeout=0.2)
+    elapsed = time.monotonic() - t0
+
+    assert 0.15 < elapsed < 2.0, f"waited {elapsed:.2f}s for a 0.2s timeout"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,152 @@
+"""
+Storage against a fake server: a dict standing in for the world's key-value store.
+"""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from miney.lua import Lua
+from miney.storage import Storage
+
+
+class FakeStorage:
+    """
+    The half of the Lua side that Storage actually talks to.
+
+    Only four snippets ever reach the server, so they are matched rather than parsed.
+    Luanti's own rules are kept: an empty value deletes, and an empty store answers
+    ``to_table().fields`` with nil.
+    """
+
+    def __init__(self, fields: dict[str, str] | None = None):
+        self.fields = dict(fields or {})
+        self.calls: list[str] = []
+
+    def run(self, code: str):
+        self.calls.append(code)
+        if code == "return storage:to_table().fields":
+            return dict(self.fields) or None
+        if code == "storage:from_table(nil) return true":
+            self.fields.clear()
+            return True
+        if code.startswith("storage:set_string("):
+            key, value = json.loads("[" + code[len("storage:set_string("):code.rindex(")")] + "]")
+            self.fields[key] = value
+            return True
+        if code.startswith("local key = "):
+            key = json.loads(code[len("local key = "):code.index(" if not")])
+            if key not in self.fields:
+                return False
+            del self.fields[key]
+            return True
+        raise AssertionError(f"unexpected Lua: {code!r}")
+
+
+@pytest.fixture
+def storage() -> Storage:
+    luanti = MagicMock()
+    fake = FakeStorage({"home": "10,20,30"})
+    luanti.lua = MagicMock()
+    luanti.lua.run.side_effect = fake.run
+    luanti.lua.dumps.side_effect = Lua.dumps.__get__(luanti.lua)
+    store = Storage(luanti)
+    store.fake = fake
+    return store
+
+
+def test_reads_and_writes_like_a_dict(storage: Storage):
+    assert storage["home"] == "10,20,30"
+    storage["spawn"] = "0,0,0"
+    assert storage["spawn"] == "0,0,0"
+    assert storage.fake.fields["spawn"] == "0,0,0"
+
+
+def test_missing_key_raises_key_error(storage: Storage):
+    with pytest.raises(KeyError):
+        storage["nope"]
+    with pytest.raises(KeyError):
+        del storage["nope"]
+    assert storage.get("nope") is None
+    assert storage.get("nope", "fallback") == "fallback"
+
+
+def test_mapping_protocol(storage: Storage):
+    storage["spawn"] = "0,0,0"
+    assert "home" in storage and "nope" not in storage
+    assert len(storage) == 2
+    assert sorted(storage) == ["home", "spawn"]
+    assert dict(storage.items()) == {"home": "10,20,30", "spawn": "0,0,0"}
+    assert sorted(storage.keys()) == ["home", "spawn"]
+    assert sorted(storage.values()) == ["0,0,0", "10,20,30"]
+
+    storage.update({"a": "1"})
+    assert storage.pop("a") == "1"
+    assert storage.setdefault("home", "unused") == "10,20,30"
+
+    del storage["home"]
+    assert "home" not in storage
+
+
+def test_clear_uses_a_single_call(storage: Storage):
+    storage["a"] = "1"
+    storage.fake.calls.clear()
+    storage.clear()
+    assert storage.fake.calls == ["storage:from_table(nil) return true"]
+    assert len(storage) == 0
+
+
+def test_reading_takes_one_call_per_operation(storage: Storage):
+    """``to_table`` returns everything, so listing must not cost one call per key."""
+    storage["a"] = "1"
+    storage["b"] = "2"
+    storage.fake.calls.clear()
+    dict(storage.items())
+    assert len(storage.fake.calls) == 1
+
+
+def test_values_must_be_strings(storage: Storage):
+    with pytest.raises(TypeError, match="Storage values are strings"):
+        storage["visits"] = 42
+    with pytest.raises(TypeError, match="json.dumps"):
+        storage["seen"] = ["Steve"]
+    # The message points at the way out, and that way works.
+    storage["visits"] = str(42)
+    storage["seen"] = json.dumps(["Steve"])
+    assert int(storage["visits"]) == 42
+    assert json.loads(storage["seen"]) == ["Steve"]
+
+
+def test_empty_value_is_refused_instead_of_deleting(storage: Storage):
+    """Luanti deletes a key that is set to "". Silently doing that would be a trap."""
+    with pytest.raises(ValueError, match="del lt.storage"):
+        storage["home"] = ""
+    assert storage["home"] == "10,20,30"
+
+
+def test_keys_must_be_non_empty_strings(storage: Storage):
+    with pytest.raises(TypeError, match="Storage keys are strings"):
+        storage[7] = "x"
+    with pytest.raises(ValueError, match="cannot be empty"):
+        storage[""] = "x"
+
+
+def test_empty_store_reads_as_empty(storage: Storage):
+    storage.clear()
+    assert len(storage) == 0
+    assert dict(storage) == {}
+    assert list(storage) == []
+
+
+def test_values_with_lua_syntax_survive(storage: Storage):
+    """Everything crossing into Lua goes through dumps, quotes and backslashes included."""
+    tricky = 'He said "hi"\\ and \n stopped'
+    storage["tricky"] = tricky
+    assert storage["tricky"] == tricky
+
+
+def test_repr_shows_content_while_it_is_small(storage: Storage):
+    assert repr(storage) == "<Luanti Storage: {'home': '10,20,30'}>"
+    for index in range(6):
+        storage[f"k{index}"] = "v"
+    assert repr(storage) == "<Luanti Storage: 7 keys>"


### PR DESCRIPTION
Release 0.7.0.

A big release of small repairs, plus `lt.storage`, `lt.nodes.fill()` and seven new events.

Nothing was removed or renamed, but ten things behave differently - most importantly the
Lua mod on the server has to be updated. The changelog has a Breaking section listing all
of them, measured from 0.5.8 rather than 0.6.0, since 0.6.0 is a day old.

- `uv run pytest`: 581 passed, 1 skipped
- Sphinx `-E -n`: clean apart from the known `LuantiClient` annotation reference